### PR TITLE
Update to suggest that brew is used

### DIFF
--- a/pages/02.about/04.how-can-i-contribute-to-mautic/02.developer/docs.md
+++ b/pages/02.about/04.how-can-i-contribute-to-mautic/02.developer/docs.md
@@ -184,6 +184,8 @@ You'll also need to download the latest [Chrome WebDriver][chrome-web-driver] wh
 
 `brew cask install chromedriver`
 
+If installing manually, Unzip and move the `chromedriver` file to `/usr/local/Cellar/selenium-server-standalone/drivers/chromedriver`.
+
 Once you have Selenium installed and the WebDriver available at the specified location, open and modify the plist file found at `/usr/local/Cellar/selenium-server-standalone/3.5.3/homebrew.mxcl.selenium-server-standalone.plist`.
 
 In the `<dict><array>` block under `ProgramArguments`, add the following after the line containing `<string>-jar</string>`"

--- a/pages/02.about/04.how-can-i-contribute-to-mautic/02.developer/docs.md
+++ b/pages/02.about/04.how-can-i-contribute-to-mautic/02.developer/docs.md
@@ -180,9 +180,9 @@ If you plan on running the acceptance test suite, you'll need to have the Seleni
 
 If you're on a Mac and you use [Homebrew][homebrew], you can install Selenium by running `brew install selenium-server-standalone`.
 
-You'll also need to download the latest [Chrome WebDriver][chrome-web-driver].
+You'll also need to download the latest [Chrome WebDriver][chrome-web-driver] which can also be installed with:
 
-Unzip and move the `chromedriver` file to `/usr/local/Cellar/selenium-server-standalone/drivers/chromedriver`.
+`brew cask install chromedriver`
 
 Once you have Selenium installed and the WebDriver available at the specified location, open and modify the plist file found at `/usr/local/Cellar/selenium-server-standalone/3.5.3/homebrew.mxcl.selenium-server-standalone.plist`.
 
@@ -193,6 +193,8 @@ In the `<dict><array>` block under `ProgramArguments`, add the following after t
 <string>-Dwebdriver.chrome.driver=/usr/local/Cellar/selenium-server-standalone/drivers/chromedriver</string>
 ...
 ```
+
+> If installing via Homebrew, the path to use will be: /usr/local/bin/chromedriver
 
 With that completed, you may now start the Selenium server using `brew services start selenium-server-standalone`.
 


### PR DESCRIPTION
My experience has been that downloading the chrome webdriver manually on a Mac is fraught with issues, especially when chrome is updated. 

There is now the ability to install the chrome webdriver via Homebrew, so I think we should suggest this in the docs, as it works out of the box for me.