### PR TITLE
Update GitHub links

### DIFF
--- a/themes/mauticdocs/mauticdocs.yaml
+++ b/themes/mauticdocs/mauticdocs.yaml
@@ -6,3 +6,7 @@ streams:
         '':
           - user/themes/mauticdocs
           - user/themes/learn2
+github:
+    position: bottom                                   # top | bottom | off
+    tree: https://github.com/mautic/mautic-community-handbook/tree/main
+    commits: https://github.com/mautic/mautic-community-handbook/commits/main


### PR DESCRIPTION
This PR should update the links in the edit page footer to refer to main rather than master as the default branch.

The settings should sit in the theme but I think that we had hard-coded them someplace else!