### PR TITLE
Include testing instructions for Gitpod

### DIFF
--- a/pages/13.contributing/04.tester/docs.md
+++ b/pages/13.contributing/04.tester/docs.md
@@ -152,5 +152,5 @@ This will check out the branch called `main` which is where we started from.  No
 [vscode]: <https://code.visualstudio.com/download>
 [github]: <https://github.com/join>
 [mautic-4.1]: <https://github.com/mautic/mautic/releases/tag/4.1.0>
-[gitod]: <https://www.gitpod.com>
+[gitpod]: <https://www.gitpod.io>
 [gitpod-default]: <https://gitpod.io/#https://github.com/mautic/mautic>

--- a/pages/13.contributing/04.tester/docs.md
+++ b/pages/13.contributing/04.tester/docs.md
@@ -18,6 +18,17 @@ We are always looking out for people to help us with these processes. Even if yo
 
 Once you have a local testing environment established, it is very quick and easy to test bugs and features.
 
+## The easy way: using Gitpod
+Since the [4.1 release][mautic-4.1] support for [Gitpod][gitpod] has been introduced. 
+
+This allows you to quickly spin up a Mautic instance with a pull request applied, in the cloud. The Mautic instance also has a mail catching tool (Mailhog) and PHPMyAdmin available to view database tables.  While there will be some pull requests which can't be tested in this way (for example if they are testing the installation process) the vast majority can be.
+
+Testing with Gitpod is as simple as clicking a button. Each pull request will have a button in the description which says 'open in Gitpod'. Click this button (you may wish to open in a new tab), and wait for Mautic to be installed for you.
+
+Then simply follow the test instructions in the pull request, and report back your findings.  The default username will always be admin, and the password will be mautic.
+
+If you are testing a bug and you need to reproduce this before you apply the pull request, you can use the link [https://gitpod.io/#https://github.com/mautic/mautic][gitpod-default] to spin up a Mautic instance based on our default branch.
+
 ## Setting up a local testing environment
 
 ### Prerequisites
@@ -140,3 +151,6 @@ This will check out the branch called `main` which is where we started from.  No
 [git]: <https://git-scm.com/download/>
 [vscode]: <https://code.visualstudio.com/download>
 [github]: <https://github.com/join>
+[mautic-4.1]: <https://github.com/mautic/mautic/releases/tag/4.1.0>
+[gitod]: <https://www.gitpod.com>
+[gitpod-default]: <https://gitpod.io/#https://github.com/mautic/mautic>


### PR DESCRIPTION
As we now have Gitpod support by default, I have included this in the testers instructions as an easy way to test PRs.