### PR TITLE
Add point about scraping contact details to CoC TLF-57

### DIFF
--- a/pages/05.policies/01.code-of-conduct/docs.md
+++ b/pages/05.policies/01.code-of-conduct/docs.md
@@ -69,6 +69,7 @@ The following behaviors are considered harassment and are unacceptable within ou
 * **Unwelcome Sexual Attention or Physical Contact** Unwelcome sexual attention or unwelcome physical contact is not acceptable. This includes sexualized comments, jokes or imagery in interactions, communications or presentation materials, as well as inappropriate touching, groping, or sexual advances. This includes touching a person without permission, including sensitive areas such as their hair, pregnant stomach, mobility device (wheelchair, scooter, etc) or tattoos. This also includes physically blocking or intimidating another person. Physical contact or simulated physical contact (such as emojis like “kiss”) without affirmative consent is not acceptable. This includes sharing or distribution of sexualized images or text.
 * **Disruptive Behavior** Sustained disruption of events, forums, or meetings, including talks and presentations, will not be tolerated. This includes spamming community discussions with the solicitation of unwanted products or services.
 * **Influencing Disruptive Behavior** We will treat influencing or leading such activities the same way we treat the activities themselves, and thus the same consequences apply.
+* **Scraping contacts** by name or any other personally identifiable information for unsolicited communication is never acceptable in any form. 
 
 ## 6. Consequences of Unacceptable Behavior
 


### PR DESCRIPTION
Some time ago we had some instances of contact details from Slack being scraped and used to send unsolicited communications.

We have closed the loop by making sure that email addresses are not being shown, however we should also call this out specifically as being unacceptable behaviour.