### PR TITLE
Fix typo in link

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,34 @@
+# Since Gitpod doesn't support caching custom Dockerfiles yet, we temporarily
+# use this once which has Python 3.9 and Vale preinstalled.
+image: dennisameling/python-vale:latest
+
+tasks:
+  - before: pip install -r docs/requirements.txt
+    command: gp open .vscode/welcome.md
+
+vscode:
+  extensions:
+    - ms-python.python
+    - lextudio.restructuredtext
+    - trond-snekvik.simple-rst
+    - errata-ai.vale-server
+    - eamodio.gitlens
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: false
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: false

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+StylesPath = .github/styles
+Vocab = Mautic
+MinAlertLevel = suggestion
+[*.{md,rst}]
+BasedOnStyles = Vale, Google, Mautic

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "vale.core.useCLI": true,
+    "esbonio.server.enabled": true,
+    "vale.valeCLI.path": "/sphinx-tools/vale/vale",
+    "esbonio.sphinx.buildDir": "${workspaceFolder}/build",
+    "esbonio.sphinx.confDir": "${workspaceFolder}/docs",
+    "restructuredtext.pythonRecommendation.disabled": true,
+    "restructuredtext.preview.name": "sphinx"
+}

--- a/docs/about/what_is_mautic.rst
+++ b/docs/about/what_is_mautic.rst
@@ -4,7 +4,7 @@ What is Mautic?
 Mautic is the world's first Open Source Marketing Automation platform.
 
 It was created by DB Hurley and launched in 2014 as an Open Source project under the GPL v3 license. You can find out more on our website,
-:xref:`mautic.org`, or on the :xref:`Mautic GitHub repository`. You can :xref:`download Mautic` for free on mautic.org.
+:xref:`mautic.org`, or on the :xref:`Mautic GitHub repository`. You can :xref:`Download Mautic` for free on mautic.org.
 
 The Mautic Community are a worldwide distributed team of volunteers who are passionate about Mautic, Marketing Automation, and Open Source technologies.
 

--- a/docs/about/what_is_mautic.rst
+++ b/docs/about/what_is_mautic.rst
@@ -4,7 +4,7 @@ What is Mautic?
 Mautic is the world's first Open Source Marketing Automation platform.
 
 It was created by DB Hurley and launched in 2014 as an Open Source project under the GPL v3 license. You can find out more on our website,
-:xref:`mautic.org`, or on the :xref:`Mautic GitHub repository`. You can :xref:`Download Mautic` for free on mautic.org.
+:xref:`mautic.org`, or on the :xref:`Mautic GitHub repository`. You can :xref:`Download Mautic` for free on :xref:`mautic.org`.
 
 The Mautic Community are a worldwide distributed team of volunteers who are passionate about Mautic, Marketing Automation, and Open Source technologies.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,13 @@
-Mautic Community Handbook
+Mautic community handbook
 #########################
 
-This handbook is a central point of call for how the Mautic community is organised and managed.
+This handbook is a central point of call for understanding the management and organization of the Mautic community.
 
-The vision is that it will grow over time as the teams and governance structure evolves, with team members adding useful resources and updating processes as they mature and are refined.
+The vision is that it grows over time as the teams and governance structure evolves, with team members adding useful resources and updating processes incrementally.
 
 .. note::
 
-   This project is under active development as we replatform from our old system.
+   This project is under active development as the handbook is re-platformed from the old system.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/links/download_mautic.py
+++ b/docs/links/download_mautic.py
@@ -1,7 +1,7 @@
 from . import link
 
 link_name = "Download Mautic" 
-link_text = "Download Mautic" 
+link_text = "download Mautic" 
 link_url = "https://mautic.org/download/" 
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_org.py
+++ b/docs/links/mautic_org.py
@@ -1,6 +1,6 @@
 from . import link
 
-link_name = "mautic_org" 
+link_name = "mautic.org" 
 link_text = "mautic.org" 
 link_url = "https://mautic.org" 
 


### PR DESCRIPTION
This fixes a typo in the link name

<a href="https://gitpod.io/#https://github.com/mautic/mautic-community-handbook/pull/123"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

