### PR TITLE
Update the branching strategy

### DIFF
--- a/.github/styles/Vocab/Mautic/accept.txt
+++ b/.github/styles/Vocab/Mautic/accept.txt
@@ -81,12 +81,15 @@ Packagist
 PATCH
 patch
 PHP
+PHPUnit
 Pipedrive
 Piwik
 POST
 post
 PUT
 Rackspace
+Rebase
+rebase
 Remarketing
 Salesforce
 SAML

--- a/pages/13.contributing/02.developer/01.Code/02.Pull requests/docs.md
+++ b/pages/13.contributing/02.developer/01.Code/02.Pull requests/docs.md
@@ -9,7 +9,7 @@ taxonomy:
 ## Pull requests
 ---
 
-We highly appreciate it when developers help us by providing Pull Requests against the Mautic code base. In order to make this process as smooth as possible for everyone, we kindly ask you to follow this process step by step. 
+It's highly appreciated when developers help Mautic by providing Pull Requests against the Mautic code base. In order to make this process as smooth as possible for everyone, it's asked that you follow this process step by step. 
 
 ## Table of contents
 
@@ -52,24 +52,28 @@ remove the first two lines
         - [Executing Tests](#executing-tests)
     - [Static Analysis](#static-analysis)
 
-## Step 1: Check existing Issues and Pull Requests
+## Step 1: review existing issues and pull requests
 
-Before working on a change, check to see if someone else also raised the topic or maybe even started working on a PR by [searching on GitHub][open-issues-github].  You can also ask in the Product Team [Slack][mautic-slack] channel, #t-product.
+Before working on a change, review the existing issues and pull requests to see if someone else also raised the topic or maybe even started working on a PR by [searching on GitHub][open-issues-github].  You can also ask in the Product Team [Slack][mautic-slack] channel, #t-product.
 
-## Step 2: Feature? Check the roadmap & Feature Requests
+## Step 2: new feature? Review the roadmap & feature requests
 
 _Skip this section if you're not planning to build a new feature_.
 
-Do you want to add a new feature to Mautic? Keep in mind that there are many people requesting new features, so we can only add a limited amount of features in new releases.
+Do you want to add a new feature to Mautic? Keep in mind that there are many people requesting new features, so the Core Team can only add a limited amount of features in new releases.
 
-Please check our [Roadmap][roadmap] and existing [Feature Requests][feature-requests] to see if someone else has already suggested similiar functionality and/or is already working on it. If not, we kindly ask you to first [create a new Feature Request][create-feature-request] in the appropriate section in the Community Forums, so that it can be discussed by the community prior to development work being done.
+Please review the [Roadmap][roadmap] and existing [Feature Requests][feature-requests] to see if someone else has already suggested similar features and/or is already working on it. If not, please first [create a new Feature Request][create-feature-request] in the appropriate section in the Community Forums, so that the Community can discuss prior to development work commencing.
 
-Features that are determined not to fit within the direction of the Mautic Core goals are more than welcome to be created as plugins instead. 
+Features that don't to fit within the direction of the Mautic Core goals are more than welcome as third-party Plugins instead. 
 
-## Step 3: Sign the Mautic Contributor Agreement
-You will need to sign the [Mautic Contributors Agreement][contributor-agreement] in order to contribute code to Mautic (which can be done online).
+.. vale off
+## Step 3: sign the Mautic Contributor Agreement
 
-## Step 4: Setup your environment
+.. vale on
+
+You need to sign the [Mautic Contributors Agreement][contributor-agreement] to contribute code to Mautic - you can sign it online.
+
+## Step 4: set up your environment (or use Gitpod)
 
 ### Install the software stack 
 
@@ -78,14 +82,20 @@ For installing the software stack, please see the [Local environment setup][loca
 ### Get the Mautic source code
 
 - Create a [GitHub][github-join] account and sign in
-- Fork the Mautic repository (click on the "Fork" button)
-- After the "forking action" has completed, clone your fork locally (this will create a `mautic` directory):
+- Fork the Mautic repository by clicking the "Fork" button
+- After the "forking action" has completed, clone your fork locally - this will create a `mautic` directory - using the following command:
 
 ```
 git clone https://github.com/USERNAME/mautic.git
 ```
 
-## Step 5: Work on your Pull Request
+or, if you use the [GitHub CLI][github-cli], use 
+
+```
+gh repo clone mautic/mautic
+```
+
+## Step 5: work on your pull request
 
 ### Choose the right branch
 
@@ -93,15 +103,17 @@ Before working on a PR, you must determine on which branch you need to work. Mau
 
 Assuming that:
 
-a = current major release
-b = current minor release
-c = future major release
+a = current major release (e.g. 4 in 4.4.5)
+b = current minor release (e.g. 4.4 in 4.4.5)
+c = future major release (e.g. 5 in 5.0)
 
-* a.x for any features and enhancements (e.g. 4.x)
-* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
-* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x)
+* All PRs are made against the c.x branch in the first instance (e.g. 5.x)
+* If the PR should be merged in an earlier release than the next major release of Mautic, duplicate the PR against the relevant a.b branch for bug fixes (e.g. 4.4), or a.x branch for features and enhacements (e.g. 4.x).
+* Backwards compatibility breaking changes can only be released in a major version, so they should only ever be made against the c.x branch (e.g. 5.x)
 
-Let's say we just released a 4.0.0 version of Mautic, the following would apply:
+The exception to this rule is if the last feature release (e.g. 4.4) has already been made, then all features would be made against the c.x branch, rather than the 4.x branch. This is usually made clear in release notes, but if you're not sure, please ask in #t-product on Slack.
+
+As an example, if Mautic just released a 4.0.0 version of Mautic, the following would apply:
 
 |Mautic version|Breaking changes/features allowed?|New features/enhancements allowed?|Bug fixes allowed?|
 |---|---|---|---|
@@ -111,17 +123,19 @@ Let's say we just released a 4.0.0 version of Mautic, the following would apply:
 
 You can determine on which branch to work as follows:
 
-- `4.0` (for example), if you are fixing a bug for the 4.0.x releases of Mautic
-- `4.x`, if you are adding a new feature or enhancing an existing feature
-- `5.x`, if you are adding a new feature or enhancing an existing feature which will break backwards compatibility
+- `4.4`, if you are fixing a bug and you want your bug included in a 4.4.x releases of Mautic - you must also create a duplicate PR for the 5.x branch as well.
+- `4.x`, if you are adding a new feature or enhancing an existing feature to include in a version of Mautic 4, which is the current major release.
+- `5.x`, if you are adding a new feature or enhancing an existing feature which breaks backwards compatibility, to include in the next major version of Mautic, Mautic 5.
 
 ### Install Mautic
 
-If you are using DDEV, simply type:
-`ddev start`
-and when prompted, allow Mautic to be set up automatically.
+If you are using DDEV, type:
 
-If you are not using DDEV:
+`ddev start`
+
+and the installer takes care of the rest - the Mautic installation process happens at the command line automatically. Just wait for it to complete!
+
+If you aren't using DDEV:
 
 - Go into your Mautic folder and install the PHP Composer dependencies:
 
@@ -130,9 +144,9 @@ cd mautic
 composer install
 ```
 
-- Open Mautic in your browser, for example by going to `http://localhost/mautic` depending on your environment, if you want to install in the user interface. Follow the steps to [install Mautic][install-mautic] locally.
+- Open Mautic in your browser, for example by going to `http://localhost/mautic` depending on your environment, if you want to install in the UI. Follow the steps to [install Mautic][install-mautic] locally.
 
-### Create a Topic Branch
+### Create a topic branch
 
 Each time you want to work on a PR for a bug or on an enhancement, create a topic branch from the relevant base branch:
 
@@ -140,81 +154,89 @@ Each time you want to work on a PR for a bug or on an enhancement, create a topi
 git checkout -b BRANCH_NAME 4.x
 ```
 
-Or, if you want to provide a bug fix for the `4.0` branch, first track the remote `4.0` branch locally:
+Or, if you want to provide a bug fix for the `4.4` branch, first track the remote `4.4` branch locally:
 
 ```
-git checkout -t origin/4.0
+git checkout -t origin/4.4
 ```
 
-Then create a new branch off the `4.0` branch to work on the bug fix:
+Then create a new branch off the `4.4` branch to work on the bug fix:
 
 ```
-git checkout -b BRANCH_NAME 4.0
+git checkout -b BRANCH_NAME 4.4
 ```
 
->>>>>> Use a descriptive name for your branch (issue_XXX where XXX is the issue number is a good convention for bug fixes).
+>>>>>> Use a descriptive name for your branch - for example issue_XXX where XXX is the issue number is a good convention for bug fixes.
 
-The above checkout commands automatically switch the code to the newly created branch (check the branch you are working on with `git branch`).
+The mentioned checkout commands automatically switch the code to the newly created branch - verify the branch you are working on with `git branch`.
 
-### Work on your Pull Request
+### Work on your pull request
 
-Work on the code as much as you want and commit as much as you want; but keep in mind the following:
-- Mautic follows [Symfony's coding standards][symfony-coding-standards] by implementing a pre-commit git hook running [php-cs-fixer][php-cs-fixer], which is installed and updated with composer install/composer update. All code styling is handled automatically by the aforementioned git hook.
-- Add unit tests to prove that the bug is fixed or that the new feature actually works (see below).
-- Try hard to not break backward compatibility (if you must do so, try to provide a compatibility layer to support the old way) -- PRs that break backward compatibility have less chance to be merged as they can only be considered in a major release.
+Work on the code as much as you want and commit as much as you want, but keep in mind the following:
 
-## Step 6: Migrations needed?
+- Mautic follows [Symfony's coding standards][symfony-coding-standards] by implementing a pre-commit git hook running [php-cs-fixer][php-cs-fixer]. Mautic installs and updates this with composer install/composer update. This handles all code styling automatically.
+- Add unit tests to prove that the fixing of the bug or that the new feature actually works - see below.
 
-Sometimes, a PR needs a migration. A simple example is when a country's regions are updated. Let's say a region contains a typo, `Colmbra` should be `Coimbra`. What if the Mautic instance already has values in the database with the old value (`Colmbra` in this case)? That's where migrations come in handy. **Every time a user updates their Mautic instance, migrations run automatically.**
+- Try hard to not break backward compatibility - if you must do so, try to provide a compatibility layer to support the old way. PRs that break backward compatibility have less chance of acceptance, as they have to wait for release in a major release.
+
+## Step 6: migrations needed?
+
+Sometimes a PR needs a migration. An example is when updating a country's regions. 
+
+If a region contains a typo, `Colmbra` should be `Coimbra`, what if the Mautic instance already has values in the database with the old value - `Colmbra` in this case? 
+
+That's where migrations come in handy. **Every time a User updates their Mautic instance, migrations run automatically.**
 
 >>>  You can skip this step if you believe you don't need migrations in your PR.
 
-An example migration scenario + code can be found [here][example-migration].
+Find an example migration scenario + code [here][example-migration].
 
 In order to create a migration, you can follow these steps:
 
-1. Run `bin/console doctrine:migrations:generate` in your terminal. A new migration file will now be prepared for you:
+1. Run `bin/console doctrine:migrations:generate` in your terminal. Doctrine creates a new migration file for you:
 
 ```bash
 $ bin/console doctrine:migrations:generate 
 Generated new migration class to "/var/www/html/app/migrations/Version20201017195540.php"
 ```
 
-2. Open the file that was just created. You will see it has two functions, `preUp()` and `up()`.
-  - `preUp()` allows you to define scenarios where the migration should or should not run (e.g. only when a certain database table exists).
+2. Open the file that was just created. It has two functions, `preUp()` and `up()`.
+
+  - `preUp()` allows you to define scenarios where the migration should or shouldn't run - for example only when a certain database table exists.
+
   - `up()` runs the actual migration and allows you to do changes in Mautic's database. You can either take inspiration from other migrations in the `app/migrations` folder or learn more about migrations in [Doctrine's documentation][doctrine-migrations-docs].
 
-3. When you're done, test your migration(s) by running `migrations:execute --up VERSION`. If all looks good, you can roll back your changes with `migrations:execute --down VERSION`.
+3. When you're done, test your migration/s by running `migrations:execute --up VERSION`. If all looks good, you can roll back your changes with `migrations:execute --down VERSION`.
 
-## Step 7: Prepare your Pull Request for Submission
+## Step 7: prepare your pull request for submission
 
-You're almost ready to submit your pull request! There's three things we still need to look into:
+You're almost ready to submit your pull request. There's three things you still need to look into:
 
 1. Code Standards
 2. End-user documentation
 3. Writing tests
 
-In order to keep Mautic stable and easy to maintain, we have a hard requirement to apply the appropriate Code Standards and to write automated tests. We can't accept features and/or enhancements without appropriate tests, as it would put the stability of Mautic in danger. Why? When you try to build something in a specific part of the application, you might accidentally break another feature. With automated tests, which go through most aspects of the application, we prevent this as much as possible. 
+In order to keep Mautic stable and easy to maintain, there is a hard requirement to apply the appropriate Code Standards and to write automated tests. Mautic can't accept features and/or enhancements without appropriate tests, as it would impact the stability of Mautic. Why? When you try to build something in a specific part of Mautic, you might accidentally break another part of Mautic. With automated tests, which cover most aspects of Mautic, it's possible to prevent this as much as possible. 
 
-### Code Standards
+### Code standards
 
-Mautic follows [Symfony's coding standards][symfony-coding-standards] by implementing pre-commit git hook running [php-cs-fixer][php-cs-fixer], which is installed and updated with `composer install`/`composer update`.
+Mautic follows [Symfony's coding standards][symfony-coding-standards] by implementing pre-commit git hook running [php-cs-fixer][php-cs-fixer]. `composer install`/`composer update` installs and updates this automatically.
 
-All code styling is handled automatically by the aforementioned git hook. If you setup git hook correctly (which is true if you ever run `composer install`/`composer update` before creating a pull request), you can format your code as you like - it will be converted to Mautic code style automatically.
+The aforementioned git hook automatically deals with any code styling. If you setup git hook correctly - which is the case if you ever run `composer install`/`composer update` before creating a pull request - you can format your code as you like - the git hook converts it to Mautic's code style automatically.
 
 ### Documentation 
 
-Each new feature should include a reference to a pull request in our [End User Documentation][mautic-docs] repository and/or [Developer Documentation][developer-docs] repository if applicable.  Any enhancements or bugfixes affecting the end-user or developer experience should also be accompanied by a PR updating the relevant resources in the Documentation.
+Each new feature should include a reference to a pull request in the [End User Documentation][mautic-docs] repository and/or [Developer Documentation][developer-docs] repository if applicable. Any enhancements or bug fixes affecting the end-user or developer experience should have a PR mentioned in the description which updates the relevant resources in the Documentation.
 
 ### Writing tests
 
-All code contributions (especially enhancements/features) should include adequate and appropriate unit tests using [PHPUnit][php-unit] and/or [Symfony functional tests][symfony-functional-tests]. Pull Requests without these tests will not be merged. See below for more extensive information on Automated Tests.
+All code contributions - especially enhancements/features - should include adequate and appropriate unit tests using [PHPUnit][php-unit] and/or [Symfony functional tests][symfony-functional-tests]. The Core Team won't merge pull requests without these tests. See below for more extensive information on Automated Tests.
 
-## Step 8: Submit your Pull Request
+## Step 8: submit your pull request
 
-### Rebase your Pull Request
+### Rebase your pull request
 
-Before submitting your PR, update your branch (needed if it takes you a while to finish your changes):
+Before submitting your PR, update your branch - especially if it takes you a while to finish your changes:
 
 ```
 git checkout 4.x
@@ -224,9 +246,9 @@ git checkout BRANCH_NAME
 git rebase 4.x
 ```
 
-! Replace `4.x` with the branch you selected previously (e.g. `4.0`) if you are working on a bug fix.
+! Replace `4.x` with the branch you selected previously - for example `4.4` - if you are working on a bug fix.
 
-When doing the rebase command, you might have to fix merge conflicts. git status will show you the unmerged files. Resolve all the conflicts, then continue the rebase:
+When doing the rebase command, you might have to fix merge conflicts. `git status` shows you the un-merged files. Resolve all the conflicts, then continue the rebase:
 
 ```
 git add ... # add resolved files
@@ -239,49 +261,50 @@ Check that all tests still pass and push your branch remotely:
 git push --force origin BRANCH_NAME
 ```
 
-### Make a Pull Request
+Sometimes if there are a lot of merge conflicts, it can be easier to re-create your PR on an updated version of the branch, especially if you aren't confident in correctly resolving the conflicts. Please ask for help in #t-product if you are struggling with the rebase of your PR.
+
+### Make a pull request
 
 You can now make a pull request on the `mautic/mautic` GitHub repository.
 
 >>>>> Take care to point your pull request towards `mautic:4.0` if you want the core team to pull a bug fix based on the `4.0` branch.
 
-To ease the core team work, always include the modified components in your pull request message and provide steps how to test your fix/feature. Keep in mind that not all testers have a thorough knowledge of all of Mautic's features, nor are they all likely to be developers, therefore clear testing steps are crucial!
+To ease the core team work, always include what you have modified in your pull request message and provide steps how to test your fix/feature. Keep in mind that not all testers have a thorough knowledge of all of Mautic's features, nor are they all likely to be developers, therefore clear testing steps are crucial.
 
-## Step 9: Receiving feedback
+## Step 9: receiving feedback
 
-We ask all contributors to follow some best practices to ensure a constructive feedback process.
+It's asked of all contributors to follow some best practices to ensure a constructive feedback process.
 
-If you think someone fails to keep this advice in mind and you want another perspective, please join the #dev channel on [Mautic Slack][mautic-slack].
+If you think someone fails to keep this advice in mind and you want another perspective, please request a review of the feedback in the #dev channel on [Mautic Slack][mautic-slack].
 
-The [Product Team][product-team] is responsible for deciding which PRs get merged, so their feedback is the most relevant. So, do not feel pressured to refactor your code immediately when someone provides feedback, wait for the Product Team to review.
+The [Product Team][product-team] is responsible for deciding which PRs get merged, so their feedback is the most relevant. So, don't feel pressured to refactor your code immediately when someone provides feedback, wait for the Product Team to review.
 
-### Rework your Pull Request
+### Rework your pull request
 
-Based on the feedback on the pull request, you might need to rework your PR. Before re-submitting the PR, rebase with `upstream/4.x` or `upstream/4.0`, don't merge; and force the push to the origin:
+Based on the feedback on the pull request, you might need to rework your PR. Before re-submitting the PR, rebase with `upstream/4.x` or `upstream/4.4` as appropriate - don't merge - and force the push to the origin:
 
 ```
 git rebase -f upstream/4.x
 git push --force origin BRANCH_NAME
 ```
 
->>>>>> When doing a push --force, always specify the branch name explicitly to avoid messing other branches in the repository (--force tells Git that you really want to mess with things, so do it carefully).
+>>>>>> When doing a push --force, **always** specify the branch name explicitly to avoid messing up other branches in the repository. `--force` tells Git that you **really** want to mess with things, so do it carefully.
 
 ## Testing
 
-### Pull Request Testing
+### Pull request testing
 
-If you want to test a pull request from other developers, see [Testing Pull Requests][testing-prs].  All pull requests need to be tested by others in the community, and have the code reviewed by a member of the core team.  Read more about this in our [code governance][code-governance] information.
+If you want to test a pull request from other developers, see [Testing Pull Requests][testing-prs].  All pull requests have a requirement for testing by others in the community, and must have the code reviewed by a member of the core team. Read more about this in the [code governance][code-governance] information.
 
-### Automated Testing
+### Automated testing
 
-Mautic uses [PHPUnit][php-unit] and [Selenium][selenium] as our suite of testing tools. 
+Mautic uses [PHPUnit][php-unit] and [Selenium][selenium] as the suite of testing tools. 
 
 #### PHPUnit
 
-Before executing unit tests, copy the `.env.dist` file to `.env` then update to reflect your local environment
-configuration.
+Before executing unit tests, copy the `.env.dist` file to `.env` then update to reflect your local environment configuration.
 
-**Running functional tests without setting the .env file with a different database will result in the configured database being overwritten.**
+**Running functional tests without setting the .env file with a different database results in the configured database being overwritten.**
 
 To run the entire test suite: 
 
@@ -290,20 +313,22 @@ bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
 ```
 
 To run tests for a specific bundle:
+
 ```bash
 bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --filter EmailBundle
 ```
 
 To run a specific test:
+
 ```bash
 bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --filter "/::testVariantEmailWeightsAreAppropriateForMultipleContacts( .*)?$/" Mautic\EmailBundle\Tests\EmailModelTest app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
 ```
 
-### Static Analysis
+### Static analysis
 
 Mautic uses [PHPSTAN][phpstan] for some of its parts during continuous integration tests. If you want to test your specific contribution locally, install PHPSTAN globally with `composer global require phpstan/phpstan-shim`. 
 
-Mautic cannot have PHPSTAN as its dev dependency, because it requires PHP7+. To run analysis on a specific bundle, run `~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/*Bundle`
+Mautic can't have PHPSTAN as its dev dependency, because it requires PHP7+. To run analysis on a specific bundle, run `~/.composer/vendor/phpstan/phpstan-shim/phpstan.phar analyse app/bundles/*Bundle`
 
 [mautic-contributors-agreement]: <https://www.mautic.org/contributor-agreement>
 [symfony-coding-standards]: <http://symfony.com/doc/current/contributing/code/standards.html>
@@ -329,3 +354,4 @@ Mautic cannot have PHPSTAN as its dev dependency, because it requires PHP7+. To 
 [mautic-slack]: <https://mautic.org/slack>
 [install-mautic]: <https://docs.mautic.org/en/setup/how-to-install-mautic>
 [code-governance]: </community-structure/governance/code-governance>
+[github-cli]: <https://cli.github.com>


### PR DESCRIPTION
This PR updates the branching strategy information for developers with specific reference to having to make a duplicate PR for the Major and Minor branches.

It also fixes a bunch of Vale warnings now I am starting to move this over to Read the Docs ... figured I might as well start working on fixing the errors in the page as I was making the PR!