### PR TITLE
Small fix to ordered layout on the integrations policy

### DIFF
--- a/pages/06.policies/09.Promoting-integrations/docs.md
+++ b/pages/06.policies/09.Promoting-integrations/docs.md
@@ -25,11 +25,13 @@ The projects listed on the Mautic website home page are selected based on their 
 1. Popularity:
 
 - Projects that have gained popularity within the Mautic community are more likely to be featured on the home page, as members are more likely to vote for them.
+
 2. Use Cases:
 
 - Projects that demonstrate a clear alignment with Mautic's use cases and goals will be given priority.
 
 - The Marketing Team will assess how well a project addresses the needs of Mautic users and enhances their experience.
+
 3. Members:
 
 - Projects that are members of Mautic will be given priority over those that are not.


### PR DESCRIPTION
Just a very small fix - doesn't need review.

<a href="https://gitpod.io/#https://github.com/mautic/mautic-community-handbook/pull/177"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

