### PR TITLE
Update password complexity for test users

### DIFF
--- a/pages/15.contributing/04.tester/docs.md
+++ b/pages/15.contributing/04.tester/docs.md
@@ -37,7 +37,7 @@ Once you have the browser extension installed, click the green button -  the fir
 
 Once the installer is done, it shows the URLs for the Mautic user interface, as well as for Mailhog and PHPMyAdmin (in case you need to check outgoing emails or test things in the database). It also shows you the default credentials to use for the login. Sometimes it can take a few minutes for the process to complete, so please wait until it does!
 
-Then follow the test instructions in the pull request, and [report back your findings][report-findings].  The default username will always be admin, and the password will be `Maut1cR0cks!`.
+Then follow the test instructions in the pull request, and [report back your findings][report-findings].  The default username will always be admin, and the password will be `Maut1cR0cks!` (note, if you're testing an older version of Mautic than 5.1, use the password `mautic`.
 
 If you are testing a bug and you need to reproduce this before you apply the pull request, you can use the link [https://gitpod.io/#https://github.com/mautic/mautic][gitpod-default] to spin up a Mautic instance based on our default branch.
 

--- a/pages/15.contributing/04.tester/docs.md
+++ b/pages/15.contributing/04.tester/docs.md
@@ -129,6 +129,8 @@ This will install all the dependencies that Mautic requires to run, and will ins
 username: admin
 password: Maut1cR0cks!
 
+Note, if you're testing an older version of Mautic than 5.1, use the password `mautic`.
+
 It will also install some software which allows you to capture outgoing emails, called Mailhog, and PHPMyAdmin which enables you to view and interact with the database.
 
 Once this process has completed, you will be able to access your local testing instance at:

--- a/pages/15.contributing/04.tester/docs.md
+++ b/pages/15.contributing/04.tester/docs.md
@@ -37,7 +37,7 @@ Once you have the browser extension installed, click the green button -  the fir
 
 Once the installer is done, it shows the URLs for the Mautic user interface, as well as for Mailhog and PHPMyAdmin (in case you need to check outgoing emails or test things in the database). It also shows you the default credentials to use for the login. Sometimes it can take a few minutes for the process to complete, so please wait until it does!
 
-Then follow the test instructions in the pull request, and [report back your findings][report-findings].  The default username will always be admin, and the password will be mautic.
+Then follow the test instructions in the pull request, and [report back your findings][report-findings].  The default username will always be admin, and the password will be `Maut1cR0cks!`.
 
 If you are testing a bug and you need to reproduce this before you apply the pull request, you can use the link [https://gitpod.io/#https://github.com/mautic/mautic][gitpod-default] to spin up a Mautic instance based on our default branch.
 
@@ -126,8 +126,8 @@ When you are prompted whether to install Mautic, choose `yes`.
 
 This will install all the dependencies that Mautic requires to run, and will install Mautic with a default username and password:
 
-username: mautic
-password: admin
+username: admin
+password: Maut1cR0cks!
 
 It will also install some software which allows you to capture outgoing emails, called Mailhog, and PHPMyAdmin which enables you to view and interact with the database.
 


### PR DESCRIPTION
This PR updates the password complexity to use the new password which is going to be in effect from 5.1. I left a note for folks testing older versions that the password will still be just `mautic`.

<a href="https://gitpod.io/#https://github.com/mautic/mautic-community-handbook/pull/178"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

