### PR TITLE
Remove reference to Acquians on Council page

### DIFF
--- a/pages/04.community-leadership/03.community-council/docs.md
+++ b/pages/04.community-leadership/03.community-council/docs.md
@@ -14,7 +14,7 @@ taxonomy:
 ---
 ## What is the Community Council?
 
-The Community Council discusses topics that impact the community as a whole, or things which are bigger than just one team. The council normally meets every 3 months and is formed of four elected representatives from the Mautic Community, and four Acquians.
+The Community Council discusses topics that impact the community as a whole, or things which are bigger than just one team. The council normally meets every 3 months and is formed of seven elected representatives from the Mautic Community, and the Project Lead.
 
 ## Who are on the Community Council?
 


### PR DESCRIPTION
Just noticed the previous PR missed this bit cc @domidc @npracht 

<a href="https://gitpod.io/#https://github.com/mautic/mautic-community-handbook/pull/195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

