### PR TITLE
Add legal and finance team

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,3 +15,12 @@ The vision is that it grows over time as the teams and governance structure evol
    :hidden:
 
    about/what_is_mautic
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Teams
+   :hidden:
+
+   teams/legal_and_finance_team
+
+

--- a/docs/links/legal_and_finance_team_slack.py
+++ b/docs/links/legal_and_finance_team_slack.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Legal and Finance Team" 
+link_text = "#t-legal-and-finance" 
+link_url = "https://mautic.slack.com/archives/CQGQ1H2SE" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/teams/legal_and_finance_team.rst
+++ b/docs/teams/legal_and_finance_team.rst
@@ -1,0 +1,29 @@
+Legal & Finance Team
+####################
+
+Mission
+*******
+
+.. admonition:: The Legal & Finance Team's mission:
+
+   To safeguard and manage the legal and financial aspects of the Mautic community
+
+General tasks
+*************
+
+The Legal & Finance team has a responsibility for managing the financial and legal aspects of the Mautic project. This includes managing the budgets, trademark, and brand, and dealing with any issues relating to licensing, breaches of trademark and so forth.
+
+This team works closely with Mautic's fiscal host, Open Source Collective, and Mautic's legal advisors.
+
+Profiles of contributors needed in this team
+********************************************
+
+* Organisers who can provide administrative support
+* Legal knowledge and experience
+* Trademark knowledge and experience
+* Financial management
+* Budget management
+
+.. admonition:: Would you like to be involved in this team?:
+   
+   Join us in :xref:`Legal and Finance Team` on Slack


### PR DESCRIPTION
This PR fixes #225 and adds the Legal and Finance team to the new Community Handbook for Read the Docs.