### PR TITLE
Restrict the linter to only files changed in the PR

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,17 @@
+The workflow is currently configured to check the entire `docs` folder, which can be time-consuming and unnecessary when only a few files are modified in a pull request. Instead, you can modify the workflow to check only the files changed in the PR. Here's how to fix it:
+
+1. **Use `paths` filter**: This will limit the workflow to run only when files in specific paths are changed.
+2. **Use environment variables**: Set up environment variables to capture the changed files.
+3. **Modify the Vale step**: Adjust the Vale step to process only the changed files.
+
+Here is the updated workflow with the necessary changes:
+
+```yaml
 name: Linting
 on:
   pull_request:
+    paths:
+      - 'docs/**'
 
 jobs:
   prose:
@@ -22,13 +33,17 @@ jobs:
     - name: Install Python dependencies
       run: pip3 install -r docs/requirements.txt
 
+    - name: Get changed files
+      id: changed-files
+      run: |
+        echo "::set-output name=files::$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep '^docs/')"
+
     - name: Vale
       uses: errata-ai/vale-action@reviewdog
       with:
         filter_mode: added
-        # Please keep version in sync with the version in .gitpod.Dockerfile for a consistent experience
         version: 3.7.1
-        files: docs/
+        files: ${{ steps.changed-files.outputs.files }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,3 +68,8 @@ jobs:
     - name: Check links
       working-directory: docs
       run: make checklinks
+```
+
+This updates the workflow to:
+- Run only when files in the `docs` directory are changed.
+- Capture the changed files and pass them to the Vale action, ensuring only those files are checked.

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,12 +1,3 @@
-The workflow is currently configured to check the entire `docs` folder, which can be time-consuming and unnecessary when only a few files are modified in a pull request. Instead, you can modify the workflow to check only the files changed in the PR. Here's how to fix it:
-
-1. **Use `paths` filter**: This will limit the workflow to run only when files in specific paths are changed.
-2. **Use environment variables**: Set up environment variables to capture the changed files.
-3. **Modify the Vale step**: Adjust the Vale step to process only the changed files.
-
-Here is the updated workflow with the necessary changes:
-
-```yaml
 name: Linting
 on:
   pull_request:
@@ -68,8 +59,3 @@ jobs:
     - name: Check links
       working-directory: docs
       run: make checklinks
-```
-
-This updates the workflow to:
-- Run only when files in the `docs` directory are changed.
-- Capture the changed files and pass them to the Vale action, ensuring only those files are checked.

--- a/docs/overview/community.rst
+++ b/docs/overview/community.rst
@@ -4,3 +4,5 @@ Community Handbook
 This handbook is a central point of call for how the Mautic community is organised and managed.
 
 The vision is that it will grow over time as the teams and governance structure evolves, with team members adding useful resources and updating processes as they mature and are refined.
+
+If you'd like to contribute, please make a pull request!

--- a/docs/overview/community.rst
+++ b/docs/overview/community.rst
@@ -5,4 +5,4 @@ This handbook is a central point of call for how the Mautic community is organis
 
 The vision is that it will grow over time as the teams and governance structure evolves, with team members adding useful resources and updating processes as they mature and are refined.
 
-If you'd like to contribute, please make a pull request!
+If you would like to contribute, please make a pull request!


### PR DESCRIPTION
When Vale is running, it's currently checking every file in the /docs folder which is very confusing for reviewers trying to figure out what's happening.

This PR should restrict it just to the files modified in the PR made. (GitHub Pilot powered, let's see what happens).