### PR TITLE
Add Python path to VCS settings in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,9 @@
     },
     "customizations": {
         "vscode": {
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/local/bin/python"
+            },
             "extensions": [
                 "ms-python.python",
                 "swyddfa.esbonio",


### PR DESCRIPTION
@adiati98, could you please test the PR and check if the prompt still appears?

> The Esbonio Language Server is not installed in your environment. Would you like to install it?

This PR should fix it by setting the Python interpreter path in the VCS settings.