### PR TITLE
Remove Mautic features from Vale

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,4 +2,4 @@ StylesPath = .github/styles
 Vocab = Mautic
 MinAlertLevel = suggestion
 [*.{md,rst}]
-BasedOnStyles = Vale, Google, Mautic
+BasedOnStyles = Vale, Google


### PR DESCRIPTION
## Description

This PR removes "Mautic" from `BasedOnStyles` in the `.vale.ini` file to skip checks for Mautic features.

## Linked Issue

Closes #308 