### PR TITLE
Docs: Convert Event organizer to RST

### DIFF
--- a/docs/contributing/event_organizer.rst
+++ b/docs/contributing/event_organizer.rst
@@ -4,7 +4,7 @@ Event organizer
 Organizing Mautic events
 ************************
 
-Events are the beating heart of a thriving open source community, and we have quite a lot of them happening throughout the year! We hold an in-person event annually which moves continent each year, in addition to Mautic Conference Global which is held virtually. Local communities can also host a MautiCamp event - a localised conference for people in that region - and Mautic Meetups which are smaller monthly gatherings of Mauticians.
+Events are the beating heart of a thriving open source community, and we have quite a lot of them happening throughout the year. We hold an in-person event annually which moves continent each year, in addition to Mautic Conference Global which is held virtually. Local communities can also host a MautiCamp event - a localised conference for people in that region - and Mautic Meetups which are smaller monthly gatherings of Mauticians.
 
 Whether you want to help with the big international events or the regional and local events, there are lots of opportunities to put your expertise to good use and help bring Mauticians together in-person, online, or in a combination of the two.
 
@@ -13,7 +13,7 @@ Whether you want to help with the big international events or the regional and l
 Getting started
 ***************
 
-Events fall under the Community Team, so your first step is to join the Community Team Slack channel. Get an invite to join Slack [here][slack] if you aren't there already, and then you can join #t-community.
+Events fall under the :doc:`/teams/community_team/community_team`, so your first step is to join the Community Team Slack channel. Get an invite to join :xref:`Mautic Community Slack` if you aren't there already, and then you can join the ``#t-community`` channel.
 
 The team meets fortnightly on Slack, so you can scroll back and check what was being discussed in previous meetings.
 
@@ -22,7 +22,9 @@ Finding open tasks
 
 Each team maintains its own Jira board, where you can find the current open tasks and a backlog of things that the team plans to work on.
 
-Access the Community Team's board [here][community-jira].
+.. Add link to the Community Team's Jira board. It's in "jira_community_team_board.py" at the "links" folder
+
+Feel free to access the Community Team's [Jira board].
 
 If you don't already have a Jira account, please sign up for one and then ask one of the team to invite your email address to our Jira and Confluence instances.
 
@@ -40,14 +42,16 @@ Events like Mautic Conferences will tend to have their own Jira board and meetin
 Starting an event
 *****************
 
-If you want to start an event in your region, awesome!  We have some clear guidelines around what events are called which you can find [here][community-events]. Determine which kind of event you'd like to run, and then discuss your ideas with the Community Team leadership.  
+.. Add link to "/community-team/meetup-guidelines". Currently, this section is not existing.
 
-We highly recommend building a team if you're planning on organizing any kind of event, whether it's a Mautic Meetup or a MautiCamp or something bigger.  There is a lot of work involved in running events, and having more than one person in the team makes it a much more sustainable process to organize.
+If you want to start an event in your region, that's awesome. We have some clear guidelines around what events are called which you can find in the [Mautic Meetups & Events] page. Determine which kind of event you'd like to run, and then discuss your ideas with the Community Team leadership.  
+
+We highly recommend building a team if you're planning on organizing any kind of event, whether it's a Mautic Meetup or a MautiCamp or something bigger. There is a lot of work involved in running events, and having more than one person in the team makes it a much more sustainable process to organize.
 
 Work in the public domain
 *************************
 
-Unless there is significant reason not to, we default to being open and transparent.  We work in the open, usually on our shared [Google Drive folder][gdrive].  This ensures that if - for whatever reason - someone is unable to complete a task, it is easy for another contributor to pick up where they left off. It also means we can always find previous work that had been done if it needs to be re-used in the future.
+Unless there is significant reason not to, we default to being open and transparent. We work in the open, usually on our shared :xref:`Mautic Google Drive`. This ensures that if - for whatever reason - someone is unable to complete a task, it is easy for another contributor to pick up where they left off. It also means we can always find previous work that had been done if it needs to be re-used in the future.
 
 Please always ensure that you upload your work at regular (ideally daily) intervals. You can use the prefix of WIP-filename to indicate that it is currently in progress.
 
@@ -57,9 +61,3 @@ Update regularly
 Please make sure you provide regular updates on the issue in Jira, and if at any point you're not going to be able to complete the task, please call that out in a comment on the issue (or send your Team Lead a message to inform them) so that somebody else can pick it up. 
 
 We totally understand that life happens and it's easy to take on too much. No judgement at all! We try to be respectful of each other by ensuring we give as much notice as possible if we're not going to be able to fulfil a task assigned to us.
-
-[community-team]: </community-team>
-[slack]: <https://mautic.org/slack>
-[community-jira]: <https://mautic.atlassian.net/browse/TCOMM>
-[gdrive]: <https://drive.google.com/drive/folders/1OrwJXmDrrlWK3f9nxRuru0YjS7-W-1-e?usp=sharing>
-[community-events]: </community-team/meetup-guidelines>

--- a/docs/contributing/event_organizer.rst
+++ b/docs/contributing/event_organizer.rst
@@ -1,6 +1,8 @@
 Event organizer
 ###############
 
+.. vale off
+
 Organizing Mautic events
 ************************
 
@@ -60,4 +62,6 @@ Update regularly
 
 Please make sure you provide regular updates on the issue in Jira, and if at any point you're not going to be able to complete the task, please call that out in a comment on the issue (or send your Team Lead a message to inform them) so that somebody else can pick it up. 
 
-We totally understand that life happens and it's easy to take on too much. No judgement at all! We try to be respectful of each other by ensuring we give as much notice as possible if we're not going to be able to fulfil a task assigned to us.
+We totally understand that life happens and it's easy to take on too much. No judgement at all. We try to be respectful of each other by ensuring we give as much notice as possible if we're not going to be able to fulfil a task assigned to us.
+
+.. vale on

--- a/docs/contributing/event_organizer.rst
+++ b/docs/contributing/event_organizer.rst
@@ -1,0 +1,65 @@
+Event organizer
+###############
+
+Organizing Mautic events
+************************
+
+Events are the beating heart of a thriving open source community, and we have quite a lot of them happening throughout the year! We hold an in-person event annually which moves continent each year, in addition to Mautic Conference Global which is held virtually. Local communities can also host a MautiCamp event - a localised conference for people in that region - and Mautic Meetups which are smaller monthly gatherings of Mauticians.
+
+Whether you want to help with the big international events or the regional and local events, there are lots of opportunities to put your expertise to good use and help bring Mauticians together in-person, online, or in a combination of the two.
+
+.. _Getting started event organizer:
+
+Getting started
+***************
+
+Events fall under the Community Team, so your first step is to join the Community Team Slack channel. Get an invite to join Slack [here][slack] if you aren't there already, and then you can join #t-community.
+
+The team meets fortnightly on Slack, so you can scroll back and check what was being discussed in previous meetings.
+
+Finding open tasks
+==================
+
+Each team maintains its own Jira board, where you can find the current open tasks and a backlog of things that the team plans to work on.
+
+Access the Community Team's board [here][community-jira].
+
+If you don't already have a Jira account, please sign up for one and then ask one of the team to invite your email address to our Jira and Confluence instances.
+
+Once you have access, you can assign yourself to a task.
+
+Please try to chunk down larger tasks into sub-tasks, and then work on each sub-task in turn. You can add comments to the main top-level task, which makes it easier for people to keep up to date with progress.
+
+Supporting a specific event
+***************************
+
+If you would like to support a specific event, the best thing to do is find out who is leading that project, and join the relevant public Slack channel to let people know you'd like to get involved. You may need to get an invite to the working group channel, as these are often private channels.
+
+Events like Mautic Conferences will tend to have their own Jira board and meeting cadence outside of the Community Team's regular meetings, you will be able to find this out from the Slack channel.
+
+Starting an event
+*****************
+
+If you want to start an event in your region, awesome!  We have some clear guidelines around what events are called which you can find [here][community-events]. Determine which kind of event you'd like to run, and then discuss your ideas with the Community Team leadership.  
+
+We highly recommend building a team if you're planning on organizing any kind of event, whether it's a Mautic Meetup or a MautiCamp or something bigger.  There is a lot of work involved in running events, and having more than one person in the team makes it a much more sustainable process to organize.
+
+Work in the public domain
+*************************
+
+Unless there is significant reason not to, we default to being open and transparent.  We work in the open, usually on our shared [Google Drive folder][gdrive].  This ensures that if - for whatever reason - someone is unable to complete a task, it is easy for another contributor to pick up where they left off. It also means we can always find previous work that had been done if it needs to be re-used in the future.
+
+Please always ensure that you upload your work at regular (ideally daily) intervals. You can use the prefix of WIP-filename to indicate that it is currently in progress.
+
+Update regularly
+****************
+
+Please make sure you provide regular updates on the issue in Jira, and if at any point you're not going to be able to complete the task, please call that out in a comment on the issue (or send your Team Lead a message to inform them) so that somebody else can pick it up. 
+
+We totally understand that life happens and it's easy to take on too much. No judgement at all! We try to be respectful of each other by ensuring we give as much notice as possible if we're not going to be able to fulfil a task assigned to us.
+
+[community-team]: </community-team>
+[slack]: <https://mautic.org/slack>
+[community-jira]: <https://mautic.atlassian.net/browse/TCOMM>
+[gdrive]: <https://drive.google.com/drive/folders/1OrwJXmDrrlWK3f9nxRuru0YjS7-W-1-e?usp=sharing>
+[community-events]: </community-team/meetup-guidelines>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,7 @@ The vision is that it grows over time as the teams and governance structure evol
    :hidden:
 
    contributing/designer
+   contributing/event_organizer
    contributing/google_summer_of_code
    contributing/mautic_bounty_programme
    contributing/contributing_docs_rst


### PR DESCRIPTION
## Description

This PR converts the "Event organizer" page into RST.

## Linked Issue

Closes #334

## Notes

Things need to do:

- Add a link to another link file that currently is not available
- Add a link to a new link in another PR. 
- Address vale warnings and suggestions

> [!NOTE]
> See issue `#` for above tasks.