### PR TITLE
Docs: Convert Organizing Mautic conferences section to RST

### DIFF
--- a/docs/contributing/event_organizer/organizing_mautic_conferences.rst
+++ b/docs/contributing/event_organizer/organizing_mautic_conferences.rst
@@ -1,0 +1,163 @@
+Organising Mautic conferences
+#############################
+
+Here is an explanation of the roles that we have available if you would like to get involved in organising the online or in-person official Mautic Conference events in the Mautic Community.
+
+All roles will require you to work well with others, as our team is distributed around the world.  Time commitments are estimates based on experiences of running previous events.
+
+Note that this would be a best case scenario of having a larger team with people taking on smaller amounts of responsibility. In reality, it might end up that the lead takes on some of the contributor roles, if there are not enough volunteers. We should (in my opinion) try as hard as we can to build out these teams rather than have lots of work fall on a small number of shoulders.
+
+Generally speaking, the team meets once a week for a 1 hour meeting on a Monday, this has been included in the estimates.
+
+.. note::
+
+   If you're interested in contributing to one of these teams, please first join the ``#mauticon`` channel on :xref:`Mautic Community Slack` and let us know what team you're interested in joining and which role you would like to be considered for.
+
+Online conferences
+******************
+
+Mautic Conference Global events are always held virtually. This allows us to involve the widest possible audience and reach our truly global community.
+
+Leads and contributors will have their tickets covered by the event.
+
+.. list-table::
+   :widths: 10 50 40
+   :header-rows: 1
+
+   * - Role title
+     - What does it involve?
+     - What is the time commitment?
+   * - **Leadership roles**
+     -
+     -
+   * - Volunteer coordinator/s
+     - Coordinating the team of volunteers who put the event together, supported by the Project Lead and Community Team leaders.
+     - 5 to 10 hours per week on average. During the event you will need to be available for three days (the day before the event, and two days of the event).
+   * - Program lead
+     - Leading all aspects of the programming for the event including the call for speakers, session selection and scheduling. Building a team to support the sessions running smoothly on the day, including organising track leads to MC the sessions.
+     - 3 to 4 hours per week on average. During the event you will need to be available for both days of the event, and have more availability in the week leading up to the event.
+   * - Design lead
+     - Leading all aspects of the visual theme for the event including building a team to work on the creation of digital assets, merchandise and providing design support/guidance to the Marketing and outreach lead.
+     - 3 to 4 hours per week on average. This role will be quite heavily front-loaded during the time when the event is being prepared, and will have blocks of more intense activity (e.g. when creating the visual themes for the event platform)
+   * - Marketing and outreach lead
+     - Leading all aspects of promoting the event both within the Mautic community and to the wider world, supported by the Marketing Team leaders. Building a team of people to support the campaigns needed, and also rendering the videos of the sessions with the appropriate branding before uploading to YouTube and promoting them.
+     - 3 to 4 hours per week on average. During the event you will need to have more availability to monitor coverage and ensure appropriate, timely responses.
+   * - Web tech lead
+     - Leading all aspects of the web technologies required to run and promote the event. This includes building a team to manage and update the Drupal website, liaising with the platform providers and configuring the event platform to meet the requirements of the event.
+     - 2 to 3 hours per week on average. This will be front-loaded at times where there is a lot to be done (for example when the schedule is being prepared, or setting up the event platform). During the event you will need to be available to provide technical support if speakers or attendees experience difficulties, supported by the event platform support staff.
+   * - Sponsorship lead
+     - Leading the outreach to potential sponsors with a view to reaching our target income for the event. Liaising with sponsors when they agree to come on board, and being the point of contact for sponsors throughout the process.
+     - 2 to 3 hours per week on average. This will be front-loaded as much of the sponsorship outreach happens in the early days of the process, however supporting sponsors in the run up to the event will also take some time.
+   * - **Contributor roles**
+     -
+     -
+   * - Program reviewer
+     - Supporting the Program lead with reviewing submissions from speakers, voting and prioritising which sessions are selected, and helping with scheduling sessions into appropriate times in the schedule.
+     - 1 to 2 hours per week on average. This will be front-loaded in the period before the event, where sessions are being reviewed and scheduled.
+   * - Track lead
+     - Leading a track as the MC for some or all of a day. Helping speakers before the event with dry-run sessions where they are introduced to the platform and can practice their session delivery. Introducing each speaker and bringing them up onto the stage to present (or playing a pre-recorded video). Running the Q&A session after the presentation, and transitioning to the next session. You must have a strong (preferably wired) internet connection in a well lit room, and do what you can to ensure that you will be uninterrupted for the duration of your track lead session.
+     - 1 to 2 hours a week in the month leading up to the event for running dry-run sessions in the event platform and liaising with your speakers. During the event you will need to be available for at least 1 hour before your track starts, and at least 1 hour after your session ends (unless it ends at the end of the day). We require track leads who are able to support international tracks, in addition to English language tracks.
+   * - Moderator
+     - Supporting track leads and the organising team by ensuring that conduct within the event is aligned with the Mautic Code of Conduct, and taking action if there are any violations.
+     - 1 to 2 hours in the week leading up to the event to familiarise yourself with the platform, and being available during the event for specified time slots.
+   * - Design team member
+     - Supporting the Design team leader with creating the visual assets required by the event.
+     - 1 to 2 hours per week, this will likely be quite heavily front-loaded with periods of work followed by quieter times.
+   * - Marketing and outreach member
+     - Working with the Marketing & Outreach team leader to promote the event to the widest audience. You’ll be involved with a range of tasks based on your experience which might include making updates to the website, building landing pages in Mautic, setting up email campaigns, creating advertising campaigns on social media and/or search engines, writing copy for articles, creating imagery for campaigns, rendering videos from the sessions and more.
+     - Flexible to suit your schedule, but it’s a good idea to block out 1 to 2 hours per week as a minimum.
+   * - Speaker comms
+     - Working with the Marketing & Outreach team leader and the program lead, you will be responsible for creating and sending the communications between the event and our speakers.
+     - 1 to 2 hours a week from the call for speakers closing to the event.
+   * - Sponsor comms
+     - Working with the sponsorship lead, you will be responsible for creating and sending the communications between the event and our sponsors.
+     - 1 to 2 hours a week on average.
+   * - Web team member
+     - Working with the web tech lead, you’ll be helping on things like setting up the event platform, adding functionality to the Drupal website, supporting speakers with technical issues, setting up integrations between all the tools to make sure everything runs smoothly, and generally helping with all things tech.
+     - Flexible to suit your schedule, there will be periods of time where there is a lot to do, and others where there is nothing! It’s probably sensible to block out 1 to 2 hours per week as a minimum.
+   * - Runner
+     - On the day, you’ll be available as an extra pair of hands if anyone in the team needs help with something. It might be helping a speaker with a technical problem, or dealing with a question from a sponsor.
+     - 2 to 3 hours in the weeks preceding the event to familiarise yourself with the event platform, and being available during the event for specific periods of time.
+
+In-person conferences
+*********************
+
+An in-person conference has quite different requirements and timescales when compared with an online event.  Most importantly, the leaders in the team must be able to physically travel to the location of the event and be in attendance for the duration of the event.
+
+Most events will be held over two days, and will be multi-track.
+
+Leads will have their ticket, travel and accommodation covered by the event. Contributors will have their ticket covered by the event.
+
+.. list-table::
+   :widths: 10 50 40
+   :header-rows: 1
+
+   * - Role title
+     - What does it involve?
+     - What is the time commitment?
+   * - **Leadership roles**
+     -
+     -
+   * - Volunteer coordinator/s
+     - Coordinating the team of volunteers who put the event together, supported by the Project Lead and Community Team leaders.
+     - 5 to 10 hours per week on average. During the event, you will need to be available for four days (the day before the event, two days of the event and the community sprint).
+   * - Venue lead
+     - Taking the lead on liaising with the selected venue and accommodation facility, ensuring that the event runs smoothly and has all the rooms, facilities and catering required. Ideally this person should live in the same country as the event venue’s location.
+     - 2 to 3 hours per week on average. This is likely to be front-loaded during venue negotiations and site visits.
+   * - Program lead
+     - Leading all aspects of the programming for the event including the call for speakers, session selection and scheduling. Building a team to support the sessions running smoothly on the day, including track leads to MC the sessions. Organising the travel requirements for speakers (supported by the Project Lead).
+     - 4 to 5 hours per week on average. During the event you will need to be available for both days of the event, and have more availability in the week leading up to the event.
+   * - Design lead
+     - Leading all aspects of the visual theme for the event including building a team to work on the creation of digital assets, merchandise, physical design (e.g. posters, banners etc) and providing design support/guidance to the Marketing and outreach lead.
+     - 3 to 4 hours per week on average. This role will be quite heavily front-loaded during the time when the event is being prepared, and will have blocks of more intense activity (e.g. when creating the visual themes for the event platform).
+   * - Audio visual lead
+     - Leading all aspects of the audio-visual setup of the event to enable recording of sessions, processing of the videos and publishing online including building a team of volunteers to monitor the audio visual equipment during sessions.
+     - 2 to 3 hours a week on average with a significant increase in time during the weeks leading up to the event.
+   * - Marketing and outreach lead
+     - Leading all aspects of promoting the event both within the Mautic community and to the wider world, supported by the Marketing Team leaders. Building a team of people to support the campaigns needed.
+     - 4 to 5 hours per week on average. During the event, you will need to have more availability to monitor coverage and ensure appropriate, timely responses.
+   * - Web tech lead
+     - Leading all aspects of the web technologies required to run and promote the event. This primarily includes building a team to manage and update the Drupal website.
+     - 4 to 5 hours per week on average. This will be front-loaded at times where there is a lot to be done (for example when the schedule is being prepared).
+   * - Sponsorship lead
+     - Leading the outreach to potential sponsors with a view to reaching our target income for the event. Liaising with sponsors when they agree to come on board, and being the point of contact for sponsors throughout the process.
+     - 2 to 3 hours per week on average. This will be front-loaded as much of the sponsorship outreach happens in the early days of the process, however supporting sponsors in the run up to the event will also take some time.
+   * - Contribution lead
+     - Leading the contribution day sprints by organising the venue in liaison with the Venue and Program leaders, setting up a mentoring programme for new contributors to have opportunities to learn how to get started, and supporting the Mautic leadership team on the day.
+     - 2 to 3 hours per week on average. This will be quite variable and most likely loaded in the months leading up to the event.
+   * - **Contributor roles**
+     -
+     -
+   * - Program reviewer
+     - Supporting the Program lead with reviewing submissions from speakers, voting and prioritising which sessions are selected, and helping with scheduling sessions into appropriate times in the schedule.
+     - 1 to 2 hours per week on average. This will be front-loaded in the period before the event, where sessions are being reviewed and scheduled.
+   * - Track lead
+     - Leading a track as the MC for some or all of a day. Introducing each speaker and welcoming them onto the stage to present. Running the Q&A session after the presentation, and transitioning to the next session.
+     - 1 to 2 hours a week in the month leading up to the event. During the event you will need to be available for the duration of your track. We may (depending on the event and the sessions) require track leads who are able to support international tracks, in addition to English language tracks.
+   * - Social organiser
+     - Supporting the Program lead with organising social events during and after the event. You will be responsible for researching appropriate locations for social events (these may be held at the venue or externally) which cater for our diverse audience.
+     - 1 to 2 hours per week, and being available during the event to ensure everything runs smoothly.
+   * - Code of Conduct contact person
+     - Supporting track leads and the organising team by ensuring that conduct within the event is aligned with the Mautic Code of Conduct, and taking action if there are any violations.
+     - 1 to 2 hours in the week leading up to the event to familiarise yourself with the Code of Conduct, and being available during the event in case of any incidents arising.
+   * - Design team member
+     - Supporting the Design team leader with creating the visual assets required by the event.
+     - 1 to 2 hours per week, this will likely be quite heavily front-loaded with periods of work followed by quieter times.
+   * - Marketing and outreach member
+     - Working with the Marketing & Outreach team leader to promote the event to the widest audience. You’ll be involved with a range of tasks based on your experience which might include making updates to the website, building landing pages in Mautic, setting up email campaigns, creating advertising campaigns on social media and/or search engines, writing copy for articles, creating imagery for campaigns, and more.
+     - Flexible to suit your schedule, but it’s a good idea to block out 1 to 2 hours per week as a minimum.
+   * - Speaker comms
+     - Working with the Marketing & Outreach team leader and the program lead, you will be responsible for creating and sending the communications between the event and our speakers. You will also be the point of contact for speakers during the event, and will need to be on hand for any technical issues which might arise.
+     - 2 to 3 hours a week from the call for speakers closing to the event.
+   * - Sponsor comms
+     - Working with the Sponsorship lead, you will be responsible for creating and sending the communications between the event and our sponsors. You will also be the point of contact for sponsors during the event, and will need to be available the day before the event to ensure that sponsors are set up and ready for the event.
+     - 1 to 2 hours a week on average.
+   * - Web team member
+     - Working with the web tech lead, you’ll be helping on things like setting up the Drupal website, setting up integrations between all the tools to make sure everything runs smoothly, and generally helping with all things tech.
+     - Flexible to suit your schedule, there will be periods of time where there is a lot to do, and others where there is nothing! It’s probably sensible to block out 1 to 2 hours per week as a minimum.
+   * - Runner
+     - On the day, you’ll be available as an extra pair of hands if anyone in the team needs help with something. It might be helping a speaker with a technical problem, or dealing with a question from a sponsor.
+     - 2 to 3 hours in the weeks preceding the event to familiarise yourself with the event platform, and being available during the event for specific periods of time.
+   * - Contribution mentor
+     - During the contribution day, you will help new contributors with getting started. We will need mentors from all the teams who are willing to spend time welcoming newcomers. Patience and a willingness to explain our processes in a simple way are very important in this role!
+     - 1-2 hours a week in the months leading up to the event, working with the Mautic leadership team to determine best tasks for new contributors, and setting up onboarding workflows.

--- a/docs/contributing/event_organizer/organizing_mautic_conferences.rst
+++ b/docs/contributing/event_organizer/organizing_mautic_conferences.rst
@@ -1,9 +1,11 @@
-Organising Mautic conferences
+Organizing Mautic conferences
 #############################
 
-Here is an explanation of the roles that we have available if you would like to get involved in organising the online or in-person official Mautic Conference events in the Mautic Community.
+.. vale off
 
-All roles will require you to work well with others, as our team is distributed around the world.  Time commitments are estimates based on experiences of running previous events.
+Here is an explanation of the roles that we have available if you would like to get involved in organizing the online or in-person official Mautic Conference events in the Mautic Community.
+
+All roles will require you to work well with others, as our team is distributed around the world. Time commitments are estimates based on experiences of running previous events.
 
 Note that this would be a best case scenario of having a larger team with people taking on smaller amounts of responsibility. In reality, it might end up that the lead takes on some of the contributor roles, if there are not enough volunteers. We should (in my opinion) try as hard as we can to build out these teams rather than have lots of work fall on a small number of shoulders.
 
@@ -32,22 +34,22 @@ Leads and contributors will have their tickets covered by the event.
      -
    * - Volunteer coordinator/s
      - Coordinating the team of volunteers who put the event together, supported by the Project Lead and Community Team leaders.
-     - 5 to 10 hours per week on average. During the event you will need to be available for three days (the day before the event, and two days of the event).
+     - 5 to 10 hours per week on average. During the event, you will need to be available for three days: the day before the event, and two days of the event.
    * - Program lead
-     - Leading all aspects of the programming for the event including the call for speakers, session selection and scheduling. Building a team to support the sessions running smoothly on the day, including organising track leads to MC the sessions.
-     - 3 to 4 hours per week on average. During the event you will need to be available for both days of the event, and have more availability in the week leading up to the event.
+     - Leading all aspects of the programming for the event including the call for speakers, session selection, and scheduling. Building a team to support the sessions running smoothly on the day, including organizing track leads to MC the sessions.
+     - 3 to 4 hours per week on average. During the event, you will need to be available for both days of the event, and have more availability in the week leading up to the event.
    * - Design lead
-     - Leading all aspects of the visual theme for the event including building a team to work on the creation of digital assets, merchandise and providing design support/guidance to the Marketing and outreach lead.
-     - 3 to 4 hours per week on average. This role will be quite heavily front-loaded during the time when the event is being prepared, and will have blocks of more intense activity (e.g. when creating the visual themes for the event platform)
+     - Leading all aspects of the visual theme for the event, including building a team to work on the creation of digital assets, merchandise, and providing design support/guidance to the Marketing and outreach lead.
+     - 3 to 4 hours per week on average. This role will be quite heavily front-loaded during the time when the event is being prepared, and will have blocks of more intense activity, for example, when creating the visual themes for the event platform.
    * - Marketing and outreach lead
      - Leading all aspects of promoting the event both within the Mautic community and to the wider world, supported by the Marketing Team leaders. Building a team of people to support the campaigns needed, and also rendering the videos of the sessions with the appropriate branding before uploading to YouTube and promoting them.
      - 3 to 4 hours per week on average. During the event you will need to have more availability to monitor coverage and ensure appropriate, timely responses.
    * - Web tech lead
-     - Leading all aspects of the web technologies required to run and promote the event. This includes building a team to manage and update the Drupal website, liaising with the platform providers and configuring the event platform to meet the requirements of the event.
-     - 2 to 3 hours per week on average. This will be front-loaded at times where there is a lot to be done (for example when the schedule is being prepared, or setting up the event platform). During the event you will need to be available to provide technical support if speakers or attendees experience difficulties, supported by the event platform support staff.
+     - Leading all aspects of the web technologies required to run and promote the event. This includes building a team to manage and update the Drupal website, liaising with the platform providers, and configuring the event platform to meet the requirements of the event.
+     - 2 to 3 hours per week on average. This will be front-loaded at times where there is a lot to be done, for example, when the schedule is being prepared, or setting up the event platform. During the event, you will need to be available to provide technical support if speakers or attendees experience difficulties, supported by the event platform support staff.
    * - Sponsorship lead
      - Leading the outreach to potential sponsors with a view to reaching our target income for the event. Liaising with sponsors when they agree to come on board, and being the point of contact for sponsors throughout the process.
-     - 2 to 3 hours per week on average. This will be front-loaded as much of the sponsorship outreach happens in the early days of the process, however supporting sponsors in the run up to the event will also take some time.
+     - 2 to 3 hours per week on average. This will be front-loaded as much of the sponsorship outreach happens in the early days of the process. However, supporting sponsors in the run up to the event will also take some time.
    * - **Contributor roles**
      -
      -
@@ -55,16 +57,16 @@ Leads and contributors will have their tickets covered by the event.
      - Supporting the Program lead with reviewing submissions from speakers, voting and prioritising which sessions are selected, and helping with scheduling sessions into appropriate times in the schedule.
      - 1 to 2 hours per week on average. This will be front-loaded in the period before the event, where sessions are being reviewed and scheduled.
    * - Track lead
-     - Leading a track as the MC for some or all of a day. Helping speakers before the event with dry-run sessions where they are introduced to the platform and can practice their session delivery. Introducing each speaker and bringing them up onto the stage to present (or playing a pre-recorded video). Running the Q&A session after the presentation, and transitioning to the next session. You must have a strong (preferably wired) internet connection in a well lit room, and do what you can to ensure that you will be uninterrupted for the duration of your track lead session.
-     - 1 to 2 hours a week in the month leading up to the event for running dry-run sessions in the event platform and liaising with your speakers. During the event you will need to be available for at least 1 hour before your track starts, and at least 1 hour after your session ends (unless it ends at the end of the day). We require track leads who are able to support international tracks, in addition to English language tracks.
+     - Leading a track as the MC for some or all of a day. Helping speakers before the event with dry-run sessions where they are introduced to the platform and can practice their session delivery. Introducing each speaker and bringing them up onto the stage to present, or playing a pre-recorded video. Running the Q&A session after the presentation, and transitioning to the next session. You must have a strong - preferably wired - internet connection in a well lit room, and do what you can to ensure that you will be uninterrupted for the duration of your track lead session.
+     - 1 to 2 hours a week in the month leading up to the event for running dry-run sessions in the event platform and liaising with your speakers. During the event, you will need to be available for at least 1 hour before your track starts and at least 1 hour after your session ends, unless it ends at the end of the day. We require track leads who are able to support international tracks, in addition to English language tracks.
    * - Moderator
-     - Supporting track leads and the organising team by ensuring that conduct within the event is aligned with the Mautic Code of Conduct, and taking action if there are any violations.
-     - 1 to 2 hours in the week leading up to the event to familiarise yourself with the platform, and being available during the event for specified time slots.
+     - Supporting track leads and the organizing team by ensuring that conduct within the event is aligned with the Mautic Code of Conduct, and taking action if there are any violations.
+     - 1 to 2 hours in the week leading up to the event to familiarize yourself with the platform, and being available during the event for specified time slots.
    * - Design team member
      - Supporting the Design team leader with creating the visual assets required by the event.
      - 1 to 2 hours per week, this will likely be quite heavily front-loaded with periods of work followed by quieter times.
    * - Marketing and outreach member
-     - Working with the Marketing & Outreach team leader to promote the event to the widest audience. You’ll be involved with a range of tasks based on your experience which might include making updates to the website, building landing pages in Mautic, setting up email campaigns, creating advertising campaigns on social media and/or search engines, writing copy for articles, creating imagery for campaigns, rendering videos from the sessions and more.
+     - Working with the Marketing & Outreach team leader to promote the event to the widest audience. You’ll be involved with a range of tasks based on your experience which might include making updates to the website, building landing pages in Mautic, setting up email campaigns, creating advertising campaigns on social media and/or search engines, writing copy for articles, creating imagery for campaigns, rendering videos from the sessions, and more.
      - Flexible to suit your schedule, but it’s a good idea to block out 1 to 2 hours per week as a minimum.
    * - Speaker comms
      - Working with the Marketing & Outreach team leader and the program lead, you will be responsible for creating and sending the communications between the event and our speakers.
@@ -74,19 +76,19 @@ Leads and contributors will have their tickets covered by the event.
      - 1 to 2 hours a week on average.
    * - Web team member
      - Working with the web tech lead, you’ll be helping on things like setting up the event platform, adding functionality to the Drupal website, supporting speakers with technical issues, setting up integrations between all the tools to make sure everything runs smoothly, and generally helping with all things tech.
-     - Flexible to suit your schedule, there will be periods of time where there is a lot to do, and others where there is nothing! It’s probably sensible to block out 1 to 2 hours per week as a minimum.
+     - Flexible to suit your schedule. There will be periods of time where there is a lot to do, and others where there is nothing. It’s probably sensible to block out 1 to 2 hours per week as a minimum.
    * - Runner
-     - On the day, you’ll be available as an extra pair of hands if anyone in the team needs help with something. It might be helping a speaker with a technical problem, or dealing with a question from a sponsor.
-     - 2 to 3 hours in the weeks preceding the event to familiarise yourself with the event platform, and being available during the event for specific periods of time.
+     - On the day, you’ll be available as an extra pair of hands if anyone in the team needs help with something. It might be helping a speaker with a technical problem or dealing with a question from a sponsor.
+     - 2 to 3 hours in the weeks preceding the event to familiarize yourself with the event platform, and being available during the event for specific periods of time.
 
 In-person conferences
 *********************
 
-An in-person conference has quite different requirements and timescales when compared with an online event.  Most importantly, the leaders in the team must be able to physically travel to the location of the event and be in attendance for the duration of the event.
+An in-person conference has quite different requirements and timescales when compared with an online event. Most importantly, the leaders in the team must be able to physically travel to the location of the event and be in attendance for the duration of the event.
 
 Most events will be held over two days, and will be multi-track.
 
-Leads will have their ticket, travel and accommodation covered by the event. Contributors will have their ticket covered by the event.
+Leads will have their ticket, travel, and accommodation covered by the event. Contributors will have their ticket covered by the event.
 
 .. list-table::
    :widths: 10 50 40
@@ -100,30 +102,30 @@ Leads will have their ticket, travel and accommodation covered by the event. Con
      -
    * - Volunteer coordinator/s
      - Coordinating the team of volunteers who put the event together, supported by the Project Lead and Community Team leaders.
-     - 5 to 10 hours per week on average. During the event, you will need to be available for four days (the day before the event, two days of the event and the community sprint).
+     - 5 to 10 hours per week on average. During the event, you will need to be available for four days: the day before the event, two days of the event and the community sprint.
    * - Venue lead
-     - Taking the lead on liaising with the selected venue and accommodation facility, ensuring that the event runs smoothly and has all the rooms, facilities and catering required. Ideally this person should live in the same country as the event venue’s location.
+     - Taking the lead on liaising with the selected venue and accommodation facility, ensuring that the event runs smoothly and has all the rooms, facilities and catering required. Ideally, this person should live in the same country as the event venue’s location.
      - 2 to 3 hours per week on average. This is likely to be front-loaded during venue negotiations and site visits.
    * - Program lead
-     - Leading all aspects of the programming for the event including the call for speakers, session selection and scheduling. Building a team to support the sessions running smoothly on the day, including track leads to MC the sessions. Organising the travel requirements for speakers (supported by the Project Lead).
-     - 4 to 5 hours per week on average. During the event you will need to be available for both days of the event, and have more availability in the week leading up to the event.
+     - Leading all aspects of the programming for the event including the call for speakers, session selection, and scheduling. Building a team to support the sessions running smoothly on the day, including track leads to MC the sessions. Organizing the travel requirements for speakers, supported by the Project Lead.
+     - 4 to 5 hours per week on average. During the event, you will need to be available for both days of the event, and have more availability in the week leading up to the event.
    * - Design lead
-     - Leading all aspects of the visual theme for the event including building a team to work on the creation of digital assets, merchandise, physical design (e.g. posters, banners etc) and providing design support/guidance to the Marketing and outreach lead.
-     - 3 to 4 hours per week on average. This role will be quite heavily front-loaded during the time when the event is being prepared, and will have blocks of more intense activity (e.g. when creating the visual themes for the event platform).
+     - Leading all aspects of the visual theme for the event including building a team to work on the creation of digital assets, merchandise, physical design - for example, posters, banners, etc. - and providing design support/guidance to the Marketing and outreach lead.
+     - 3 to 4 hours per week on average. This role will be quite heavily front-loaded during the time when the event is being prepared, and will have blocks of more intense activity, for example, when creating the visual themes for the event platform.
    * - Audio visual lead
-     - Leading all aspects of the audio-visual setup of the event to enable recording of sessions, processing of the videos and publishing online including building a team of volunteers to monitor the audio visual equipment during sessions.
+     - Leading all aspects of the audio-visual setup of the event to enable recording of sessions, processing of the videos, and publishing online including building a team of volunteers to monitor the audio visual equipment during sessions.
      - 2 to 3 hours a week on average with a significant increase in time during the weeks leading up to the event.
    * - Marketing and outreach lead
-     - Leading all aspects of promoting the event both within the Mautic community and to the wider world, supported by the Marketing Team leaders. Building a team of people to support the campaigns needed.
+     - Leading all aspects of promoting the event, both within the Mautic community and to the wider world, supported by the Marketing Team leaders. Building a team of people to support the campaigns needed.
      - 4 to 5 hours per week on average. During the event, you will need to have more availability to monitor coverage and ensure appropriate, timely responses.
    * - Web tech lead
      - Leading all aspects of the web technologies required to run and promote the event. This primarily includes building a team to manage and update the Drupal website.
-     - 4 to 5 hours per week on average. This will be front-loaded at times where there is a lot to be done (for example when the schedule is being prepared).
+     - 4 to 5 hours per week on average. This will be front-loaded at times, where there is a lot to be done, for example, when the schedule is being prepared.
    * - Sponsorship lead
      - Leading the outreach to potential sponsors with a view to reaching our target income for the event. Liaising with sponsors when they agree to come on board, and being the point of contact for sponsors throughout the process.
-     - 2 to 3 hours per week on average. This will be front-loaded as much of the sponsorship outreach happens in the early days of the process, however supporting sponsors in the run up to the event will also take some time.
+     - 2 to 3 hours per week on average. This will be front-loaded as much of the sponsorship outreach happens in the early days of the process. However, supporting sponsors in the run up to the event will also take some time.
    * - Contribution lead
-     - Leading the contribution day sprints by organising the venue in liaison with the Venue and Program leaders, setting up a mentoring programme for new contributors to have opportunities to learn how to get started, and supporting the Mautic leadership team on the day.
+     - Leading the contribution day sprints by organizing the venue in liaison with the Venue and Program leaders, setting up a mentoring program for new contributors to have opportunities to learn how to get started, and supporting the Mautic leadership team on the day.
      - 2 to 3 hours per week on average. This will be quite variable and most likely loaded in the months leading up to the event.
    * - **Contributor roles**
      -
@@ -132,14 +134,14 @@ Leads will have their ticket, travel and accommodation covered by the event. Con
      - Supporting the Program lead with reviewing submissions from speakers, voting and prioritising which sessions are selected, and helping with scheduling sessions into appropriate times in the schedule.
      - 1 to 2 hours per week on average. This will be front-loaded in the period before the event, where sessions are being reviewed and scheduled.
    * - Track lead
-     - Leading a track as the MC for some or all of a day. Introducing each speaker and welcoming them onto the stage to present. Running the Q&A session after the presentation, and transitioning to the next session.
-     - 1 to 2 hours a week in the month leading up to the event. During the event you will need to be available for the duration of your track. We may (depending on the event and the sessions) require track leads who are able to support international tracks, in addition to English language tracks.
-   * - Social organiser
-     - Supporting the Program lead with organising social events during and after the event. You will be responsible for researching appropriate locations for social events (these may be held at the venue or externally) which cater for our diverse audience.
+     - Leading a track as the MC for some or all of a day. Introducing each speaker and welcoming them onto the stage to present. Running the Q&A session after the presentation and transitioning to the next session.
+     - 1 to 2 hours a week in the month leading up to the event. During the event, you will need to be available for the duration of your track. We may - depending on the event and the sessions - require track leads who are able to support international tracks, in addition to English language tracks.
+   * - Social organizer
+     - Supporting the Program lead with organizing social events during and after the event. You will be responsible for researching appropriate locations for social events - may be held at the venue or externally - which cater for our diverse audience.
      - 1 to 2 hours per week, and being available during the event to ensure everything runs smoothly.
    * - Code of Conduct contact person
-     - Supporting track leads and the organising team by ensuring that conduct within the event is aligned with the Mautic Code of Conduct, and taking action if there are any violations.
-     - 1 to 2 hours in the week leading up to the event to familiarise yourself with the Code of Conduct, and being available during the event in case of any incidents arising.
+     - Supporting track leads and the organizing team by ensuring that conduct within the event is aligned with the Mautic Code of Conduct and taking action if there are any violations.
+     - 1 to 2 hours in the week leading up to the event to familiarize yourself with the Code of Conduct, and being available during the event in case of any incidents arising.
    * - Design team member
      - Supporting the Design team leader with creating the visual assets required by the event.
      - 1 to 2 hours per week, this will likely be quite heavily front-loaded with periods of work followed by quieter times.
@@ -150,14 +152,16 @@ Leads will have their ticket, travel and accommodation covered by the event. Con
      - Working with the Marketing & Outreach team leader and the program lead, you will be responsible for creating and sending the communications between the event and our speakers. You will also be the point of contact for speakers during the event, and will need to be on hand for any technical issues which might arise.
      - 2 to 3 hours a week from the call for speakers closing to the event.
    * - Sponsor comms
-     - Working with the Sponsorship lead, you will be responsible for creating and sending the communications between the event and our sponsors. You will also be the point of contact for sponsors during the event, and will need to be available the day before the event to ensure that sponsors are set up and ready for the event.
+     - Working with the Sponsorship lead, you will be responsible for creating and sending the communications between the event and our sponsors. You will also be the point of contact for sponsors during the event and will need to be available the day before the event to ensure that sponsors are set up and ready for the event.
      - 1 to 2 hours a week on average.
    * - Web team member
      - Working with the web tech lead, you’ll be helping on things like setting up the Drupal website, setting up integrations between all the tools to make sure everything runs smoothly, and generally helping with all things tech.
-     - Flexible to suit your schedule, there will be periods of time where there is a lot to do, and others where there is nothing! It’s probably sensible to block out 1 to 2 hours per week as a minimum.
+     - Flexible to suit your schedule. There will be periods of time where there is a lot to do, and others where there is nothing. It’s probably sensible to block out 1 to 2 hours per week as a minimum.
    * - Runner
-     - On the day, you’ll be available as an extra pair of hands if anyone in the team needs help with something. It might be helping a speaker with a technical problem, or dealing with a question from a sponsor.
-     - 2 to 3 hours in the weeks preceding the event to familiarise yourself with the event platform, and being available during the event for specific periods of time.
+     - On the day, you’ll be available as an extra pair of hands if anyone in the team needs help with something. It might be helping a speaker with a technical problem or dealing with a question from a sponsor.
+     - 2 to 3 hours in the weeks preceding the event to familiarize yourself with the event platform and being available during the event for specific periods of time.
    * - Contribution mentor
-     - During the contribution day, you will help new contributors with getting started. We will need mentors from all the teams who are willing to spend time welcoming newcomers. Patience and a willingness to explain our processes in a simple way are very important in this role!
-     - 1-2 hours a week in the months leading up to the event, working with the Mautic leadership team to determine best tasks for new contributors, and setting up onboarding workflows.
+     - During the contribution day, you will help new contributors with getting started. We will need mentors from all the teams who are willing to spend time welcoming newcomers. Patience and a willingness to explain our processes in a simple way are very important in this role.
+     - 1 to 2 hours a week in the months leading up to the event, working with the Mautic leadership team to determine best tasks for new contributors and setting up onboarding workflows.
+
+.. vale on

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,7 @@ The vision is that it grows over time as the teams and governance structure evol
    :hidden:
 
    contributing/designer
+   contributing/event_organizer/organizing_mautic_conferences
    contributing/google_summer_of_code
    contributing/mautic_bounty_programme
    contributing/contributing_docs_rst


### PR DESCRIPTION
## Description

This PR converts the "Organizing Mautic conferences" page into RST.

## Linked Issue

Closes #336

## Notes

Things need to do:

- Address vale errors, warnings, and suggestions

> [!NOTE]
> See issue `#` for above tasks.