### PR TITLE
Docs: Convert Tester section into RST

### DIFF
--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -31,6 +31,7 @@ Cron
 CTRL
 Custom Fields
 DDEV
+dev
 Do Not Contact
 doxing
 DNC
@@ -104,6 +105,7 @@ PUT
 Rackspace
 Rebase
 rebase
+Raycast
 Remarketing
 Salesforce
 Stumptown

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,4 +71,6 @@ linkcheck_ignore = [
     r"https://docs.mautic.org/policies/financial-policy#10-foreign-assets-control",
     # The GitHub Search UI requires users to be authenticated with session cookies, which we can't set up programmatically
     r"https://github.com/search*",
+    # Gitpod URLs often follow the pattern https://gitpod.io/#<repository_url>, which is not in the traditional sense for an HTML page
+    r'https://gitpod\.io/.*',
 ]

--- a/docs/contributing/tester.rst
+++ b/docs/contributing/tester.rst
@@ -11,16 +11,16 @@ Here is a video which explains the easy way as outlined below:
 
 <div class="grav-youtube"><iframe width="560" height="315" src="https://www.youtube.com/embed/fqnT3kaDaW4?si=KXwViqwFBZzfog9h" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
-We maintain a board which shows you a list of all of the bugs and features that we want to get tested -  check it out here: [Open Source Friday board][open-source-friday-board].
+Mautic maintains :xref:`Mautic OSS Fridays board` which shows you a list of all of the bugs and features that we want to get tested.
 
 The easy way: using Gitpod
 **************************
 
-Since the [4.1 release][mautic-4.1] support for [Gitpod][gitpod] has been introduced. 
+Since the :xref:`Mautic 4.1 release` support for :xref:`Gitpod` has been introduced. 
 
 This allows you to quickly spin up a Mautic instance with a pull request applied, in the cloud. The Mautic instance also has a mail catching tool (Mailhog) and PHPMyAdmin available to view database tables.  While there will be some pull requests which can't be tested in this way (for example if they are testing the installation process) the vast majority can be.
 
-Testing  a bug or a new feature with Gitpod is as simple as clicking a button once you have installed the [Gitpod Browser Extension][gitpod-browser] in Chrome and Firefox. 
+Testing  a bug or a new feature with Gitpod is as simple as clicking a button once you have installed the :xref:`Gitpod Browser Extension` in Chrome and Firefox. 
 
 This will add a green 'Gitpod' button on the right hand side of every pull request, and has the added benefit of also adding the button on the main repository and any branch or tag, allowing you to quickly spin up a specific version of Mautic in Gitpod. You can also copy the URL of the PR and open a Gitpod instance manually on your Gitpod dashboard, or using various automation tools like Alfred or Raycast.  
 
@@ -28,13 +28,13 @@ Once you have the browser extension installed, click the green button -  the fir
 
 Once the installer is done, it shows the URLs for the Mautic user interface, as well as for Mailhog and PHPMyAdmin (in case you need to check outgoing emails or test things in the database). It also shows you the default credentials to use for the login. Sometimes it can take a few minutes for the process to complete, so please wait until it does!
 
-Then follow the test instructions in the pull request, and [report back your findings][report-findings]. The default username will always be admin, and the password will be ``Maut1cR0cks!``.
+Then follow the test instructions in the pull request, and :ref:`report back your findings<Leaving your review>`. The default username will always be admin, and the password will be ``Maut1cR0cks!``.
 
 .. note::
 
    If you're testing an older version of Mautic than ``5.1``, use the password ``mautic``.
 
-If you are testing a bug and you need to reproduce this before you apply the pull request, you can use the link [https://gitpod.io/#https://github.com/mautic/mautic][gitpod-default] to spin up a Mautic instance based on our default branch.
+If you are testing a bug and you need to reproduce this before you apply the pull request, you can use this link :xref:`Mautic Gitpod link` to spin up a Mautic instance based on our default branch.
 
 Top tips
 ========
@@ -78,7 +78,7 @@ In DDEV we can set the database and PHP version in a file located in the folder 
 Resetting your local testing environment
 ----------------------------------------
 
-To quickly reset your local testing environment by deleting the DDEV containers without a database snapshot, removing the cache directory, and removing the ``local.php`` file you can run ``ddev delete --omit-snapshot --yes && rm -rf var/cache && rm app/config/local.php``. 
+To quickly reset your local testing environment by deleting the DDEV containers without a database snapshot, removing the cache directory, and removing the ``local.php`` file, you can run ``ddev delete --omit-snapshot --yes && rm -rf var/cache && rm app/config/local.php``. 
 
 Note that from Mautic 5, the location of the ``local.php`` file is now ``config/local.php``.
 
@@ -89,14 +89,15 @@ Prerequisites
 =============
 
 Before starting, you will need a few pieces of software on your computer:
-* [Docker Desktop][docker-desktop]
-* [DDEV][ddev]
-* [Git][git]
-* [GitHub CLI][github-cli]
 
-Once you have these installed, we recommend that you use an editor such as [Visual Studio Code][vscode] which will allow you to interact with files, folders and the command line. There are other editors and Integrated Development Environments (IDEs) so if you already have one that you like, by all means use that!
+* :xref:`Docker Desktop`
+* :xref:`DDEV get started`
+* :xref:`Git downloads`
+* :xref:`GitHub CLI`
 
-You will also need to register for an account at [github.com][github] if you don't already have one. This allows you to leave comments when you've tested things, and also means you can make fixes yourself in the future.
+Once you have these installed, we recommend that you use an editor such as :xref:`VS Code` which will allow you to interact with files, folders and the command line. There are other editors and Integrated Development Environments (IDEs) so if you already have one that you like, by all means use that!
+
+You will also need to register for an account at :xref:`GitHub signup` if you don't already have one. This allows you to leave comments when you've tested things, and also means you can make fixes yourself in the future.
 
 Downloading Mautic
 ==================
@@ -127,7 +128,7 @@ Once you are in the folder you want to work from, we need to pull down a copy of
 
 The first time you run this command, it will ask you to authenticate with GitHub. Just follow the steps, and once you've set up the authentication it won't bother you for some time.
 
-This will pull down the GitHub repository at [https://github.com/mautic/mautic][mautic-repo] to your local machine, ready for you to start testing with.
+This will pull down the GitHub repository at :xref:`Mautic GitHub repository` to your local machine, ready for you to start testing with.
 
 Setting up a local DDEV instance
 ================================
@@ -190,7 +191,7 @@ Using developer mode
 
 When testing Mautic, it is important that you are notified of any errors rather than having them output to the logs.  We also don't want to have to constantly rebuild the JavaScript and CSS files when changes are made.
 
-For this reason, we use developer mode when testing in the Mautic Community, which is set in the local environment file.  DDEV has dev mode enabled by default - read more about [environments][environments].  
+For this reason, we use developer mode when testing in the Mautic Community, which is set in the local environment file.  DDEV has dev mode enabled by default - read more about :xref:`Mautic environments docs` on Mautic Developer Documentation.  
 
 Testing your first pull request
 *******************************
@@ -240,19 +241,3 @@ Once you are done with testing the pull request, it is good practice to get back
 Where 5.x is the branch that you want to return to.
 
 This will check out the branch called ``5.x`` which is where we started from.  Now you're ready to go and find another pull request to test! Have a little celebration, you helped make Mautic even more awesome! THANK YOU!
-
-
-[gitpod-browser]: <https://www.gitpod.io/docs/configure/user-settings/browser-extension>
-[docker-desktop]: <https://www.docker.com/products/docker-desktop>
-[ddev]: <https://ddev.readthedocs.io/en/stable/#installation>
-[github-cli]: <https://cli.github.com>
-[git]: <https://git-scm.com/download/>
-[vscode]: <https://code.visualstudio.com/download>
-[github]: <https://github.com/join>
-[mautic-repo]: <https://github.com/mautic/mautic>
-[environments]: <https://devdocs.mautic.org/en/5.x/development-environment/environments.html>
-[mautic-4.1]: <https://github.com/mautic/mautic/releases/tag/4.1.0>
-[gitpod]: <https://www.gitpod.io>
-[gitpod-default]: <https://gitpod.io/#https://github.com/mautic/mautic>
-[report-findings]: <https://contribute.mautic.org/contributing-to-mautic/tester#leaving-your-review>
-[open-source-friday-board]: <https://github.com/orgs/mautic/projects/13?pane=info>

--- a/docs/contributing/tester.rst
+++ b/docs/contributing/tester.rst
@@ -1,6 +1,8 @@
 Tester
 ######
 
+.. vale off
+
 Every new feature and bug fix that is released in Mautic has undergone testing and code review by members of the community before it makes it into a release.
 
 We are always looking out for people to help us with these processes. Even if you can spare an hour or two a week, it would significantly increase the number of bugs and features that make it out into the hands of Mautic users.
@@ -18,15 +20,15 @@ The easy way: using Gitpod
 
 Since the :xref:`Mautic 4.1 release` support for :xref:`Gitpod` has been introduced. 
 
-This allows you to quickly spin up a Mautic instance with a pull request applied, in the cloud. The Mautic instance also has a mail catching tool (Mailhog) and PHPMyAdmin available to view database tables.  While there will be some pull requests which can't be tested in this way (for example if they are testing the installation process) the vast majority can be.
+This allows you to quickly spin up a Mautic instance with a pull request applied, in the cloud. The Mautic instance also has a mail catching tool (MailHog) and PHPMyAdmin available to view database tables. While there will be some pull requests which can't be tested in this way (for example if they are testing the installation process) the vast majority can be.
 
 Testing  a bug or a new feature with Gitpod is as simple as clicking a button once you have installed the :xref:`Gitpod Browser Extension` in Chrome and Firefox. 
 
 This will add a green 'Gitpod' button on the right hand side of every pull request, and has the added benefit of also adding the button on the main repository and any branch or tag, allowing you to quickly spin up a specific version of Mautic in Gitpod. You can also copy the URL of the PR and open a Gitpod instance manually on your Gitpod dashboard, or using various automation tools like Alfred or Raycast.  
 
-Once you have the browser extension installed, click the green button -  the first time it will ask you to log in with GitHub.  You may wish to open in a new tab, so that it's easy to reference back to the pull request. Now you just have to wait for Mautic to be installed for you. 
+Once you have the browser extension installed, click the green button - the first time it will ask you to log in with GitHub. You may wish to open in a new tab, so that it's easy to reference back to the pull request. Now you just have to wait for Mautic to be installed for you. 
 
-Once the installer is done, it shows the URLs for the Mautic user interface, as well as for Mailhog and PHPMyAdmin (in case you need to check outgoing emails or test things in the database). It also shows you the default credentials to use for the login. Sometimes it can take a few minutes for the process to complete, so please wait until it does!
+Once the installer is done, it shows the URLs for the Mautic user interface, as well as for MailHog and PHPMyAdmin (in case you need to check outgoing emails or test things in the database). It also shows you the default credentials to use for the login. Sometimes, it can take a few minutes for the process to complete, so please wait until it does.
 
 Then follow the test instructions in the pull request, and :ref:`report back your findings<Leaving your review>`. The default username will always be admin, and the password will be ``Maut1cR0cks!``.
 
@@ -42,7 +44,7 @@ Top tips
 Installing sample data
 ----------------------
 
-To quickly install sample data, use the command ``ddev exec bin/console d:f:l`` which loads the Doctrine fixtures. It gives you a big head start with testing! 
+To quickly install sample data, use the command ``ddev exec bin/console d:f:l`` which loads the Doctrine fixtures. It gives you a big head start with testing.
 
 Build the segments after install
 --------------------------------
@@ -71,7 +73,7 @@ In DDEV we can set the database and PHP version in a file located in the folder 
 
 #. Check you are using the right version in the system information within Mautic.
 
-#. Remember to make sure you are using dev mode - DDEV should start in dev mode by default with the Symfony toolbar at the bottom of the page.
+#. Remember to make sure you are using dev mode - DDEV should start in dev mode by default, with the Symfony toolbar at the bottom of the page.
 
 #. If you make a mistake, open your Gitpod dashboard and delete the instance and start again.
 
@@ -95,7 +97,7 @@ Before starting, you will need a few pieces of software on your computer:
 * :xref:`Git downloads`
 * :xref:`GitHub CLI`
 
-Once you have these installed, we recommend that you use an editor such as :xref:`VS Code` which will allow you to interact with files, folders and the command line. There are other editors and Integrated Development Environments (IDEs) so if you already have one that you like, by all means use that!
+Once you have these installed, we recommend that you use an editor such as :xref:`VS Code` which will allow you to interact with files, folders, and the command line. There are other editors and Integrated Development Environments (IDEs) so if you already have one that you like, by all means use that.
 
 You will also need to register for an account at :xref:`GitHub signup` if you don't already have one. This allows you to leave comments when you've tested things, and also means you can make fixes yourself in the future.
 
@@ -108,13 +110,13 @@ Before we do that, let's create a folder in your local computer where you'll loc
 
 Open your editor, and within the editor, open a terminal window.  
 
-In the terminal, we need to move into the directory we just created.  Use the following commands:
+In the terminal, we need to move into the directory we just created. Use the following commands:
 
 .. code-block:: bash
 
    cd users/yourusername/yourfolder/mautic4
 
-If you need to move up an directory, for example back to ``/yourfolder/``, you can use the command:
+If you need to move up an directory, for example, back to ``/yourfolder/``, you can use the command:
 
 .. code-block:: bash
 
@@ -162,11 +164,11 @@ This will install all the dependencies that Mautic requires to run, and will ins
 
    If you're testing an older version of Mautic than ``5.1``, use the password ``mautic``.
 
-It will also install some software which allows you to capture outgoing emails, called Mailhog, and PHPMyAdmin, which enables you to view and interact with the database.
+It will also install some software which allows you to capture outgoing emails, called MailHog, and PHPMyAdmin, which enables you to view and interact with the database.
 
 Once this process has completed, you will be able to access your local testing instance at ``https://mautic.ddev.site``.
 
-Log in with the credentials above, and you're ready to go!
+Log in with the credentials above, and you're ready to go.
 
 .. tip::
 
@@ -189,16 +191,16 @@ Log in with the credentials above, and you're ready to go!
 Using developer mode
 ********************
 
-When testing Mautic, it is important that you are notified of any errors rather than having them output to the logs.  We also don't want to have to constantly rebuild the JavaScript and CSS files when changes are made.
+When testing Mautic, it is important that you are notified of any errors rather than having them output to the logs. We also don't want to have to constantly rebuild the JavaScript and CSS files when changes are made.
 
-For this reason, we use developer mode when testing in the Mautic Community, which is set in the local environment file.  DDEV has dev mode enabled by default - read more about :xref:`Mautic environments docs` on Mautic Developer Documentation.  
+For this reason, we use developer mode when testing in the Mautic Community, which is set in the local environment file. DDEV has dev mode enabled by default - read more about :xref:`Mautic environments docs` on Mautic Developer Documentation.  
 
 Testing your first pull request
 *******************************
 
 The first step when testing a bug is to attempt reproducing the bug and making sure that you are experiencing the problem that the developer is fixing.
 
-Generally there will be instructions in the description of the pull request, but sometimes you might have to refer to an issue which reported the bug in order to find instructions for reproducing the issue.  If you don't understand, or can't reproduce the issue, please leave a comment and the developer will get back to you with further instructions.
+Generally there will be instructions in the description of the pull request, but sometimes you might have to refer to an issue which reported the bug in order to find instructions for reproducing the issue. If you don't understand, or can't reproduce the issue, please leave a comment and the developer will get back to you with further instructions.
 
 Once you have confirmed the bug, we need to apply the fix. We do this with another GitHub CLI command:
 
@@ -218,26 +220,33 @@ If you ever need to clear the cache, you can either delete the cache folder manu
 
 Note that we have to prefix any commands with ``ddev exec`` so that they run inside the Docker container. We also use the ``--env=dev`` argument to specify that we need to clear the development (rather than production) cache.
 
-Now that you have the pull request applied, the next step is to re-test the bug or check out the new feature.  Make sure you are thorough in your testing. Really think about every possible thing that might be affected by the changes being made in the pull request, and test it in detail.
+Now that you have the pull request applied, the next step is to re-test the bug or check out the new feature. Make sure you are thorough in your testing. Really think about every possible thing that might be affected by the changes being made in the pull request, and test it in detail.
 
 It's very helpful if you can write a comment and explain what you have tested.
 
 Leaving your review
 *******************
 
-Within GitHub, there is a built-in system for people to leave reviews.  At the top of the pull request you will see a tab which is called 'Files Changed'. In this tab, at the top right, you'll see a green button which allows you to start a review.
+Within GitHub, there is a built-in system for people to leave reviews. At the top of the pull request you will see a tab which is called 'Files Changed'. In this tab, at the top right, you'll see a green button which allows you to start a review.
 
-From this point, you can write what you have found when testing the pull request. You can select whether you approve the pull request, whether you think there are changes needed (e.g. if you weren't able to get the results that you expected) or just leave a comment if you're not sure either way, or just want to leave some feedback.
+From this point, you can write what you have found when testing the pull request. You can select whether you:
+
+* approve the pull request,
+* need to ask for some changes, for instance, if you weren't able to get the results that you expected,
+* leave a comment if you're not sure either way,
+* want to leave some feedback.
 
 Unloading the pull request
 **************************
 
-Once you are done with testing the pull request, it is good practice to get back to the original state. To do this use the command:
+Once you are done with testing the pull request, it is good practice to get back to the original state. To do this, use the command:
 
 .. code-block:: bash
 
    git checkout 5.x
 
-Where 5.x is the branch that you want to return to.
+Where ``5.x`` is the branch that you want to return to.
 
-This will check out the branch called ``5.x`` which is where we started from.  Now you're ready to go and find another pull request to test! Have a little celebration, you helped make Mautic even more awesome! THANK YOU!
+This will check out the branch called ``5.x`` which is where we started from. Now you're ready to go and find another pull request to test. Have a little celebration because you helped make Mautic even more awesome. Thank you for your contribution.
+
+.. vale on

--- a/docs/contributing/tester.rst
+++ b/docs/contributing/tester.rst
@@ -7,9 +7,9 @@ We are always looking out for people to help us with these processes. Even if yo
 
 Once you have a local testing environment established (or you have a free account on GitHub which allows you to use Gitpod), it is very quick and easy to test bugs and features.
 
-Here is a video which explains the easy way as outlined below:
+.. tip::
 
-<div class="grav-youtube"><iframe width="560" height="315" src="https://www.youtube.com/embed/fqnT3kaDaW4?si=KXwViqwFBZzfog9h" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+  You can watch the short tutorial about :xref:`How to test bugs and features in Mautic` on YouTube, which explains the easy way to do it.
 
 Mautic maintains :xref:`Mautic OSS Fridays board` which shows you a list of all of the bugs and features that we want to get tested.
 

--- a/docs/contributing/tester.rst
+++ b/docs/contributing/tester.rst
@@ -1,0 +1,258 @@
+Tester
+######
+
+Every new feature and bug fix that is released in Mautic has undergone testing and code review by members of the community before it makes it into a release.
+
+We are always looking out for people to help us with these processes. Even if you can spare an hour or two a week, it would significantly increase the number of bugs and features that make it out into the hands of Mautic users.
+
+Once you have a local testing environment established (or you have a free account on GitHub which allows you to use Gitpod), it is very quick and easy to test bugs and features.
+
+Here is a video which explains the easy way as outlined below:
+
+<div class="grav-youtube"><iframe width="560" height="315" src="https://www.youtube.com/embed/fqnT3kaDaW4?si=KXwViqwFBZzfog9h" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+We maintain a board which shows you a list of all of the bugs and features that we want to get tested -  check it out here: [Open Source Friday board][open-source-friday-board].
+
+The easy way: using Gitpod
+**************************
+
+Since the [4.1 release][mautic-4.1] support for [Gitpod][gitpod] has been introduced. 
+
+This allows you to quickly spin up a Mautic instance with a pull request applied, in the cloud. The Mautic instance also has a mail catching tool (Mailhog) and PHPMyAdmin available to view database tables.  While there will be some pull requests which can't be tested in this way (for example if they are testing the installation process) the vast majority can be.
+
+Testing  a bug or a new feature with Gitpod is as simple as clicking a button once you have installed the [Gitpod Browser Extension][gitpod-browser] in Chrome and Firefox. 
+
+This will add a green 'Gitpod' button on the right hand side of every pull request, and has the added benefit of also adding the button on the main repository and any branch or tag, allowing you to quickly spin up a specific version of Mautic in Gitpod. You can also copy the URL of the PR and open a Gitpod instance manually on your Gitpod dashboard, or using various automation tools like Alfred or Raycast.  
+
+Once you have the browser extension installed, click the green button -  the first time it will ask you to log in with GitHub.  You may wish to open in a new tab, so that it's easy to reference back to the pull request. Now you just have to wait for Mautic to be installed for you. 
+
+Once the installer is done, it shows the URLs for the Mautic user interface, as well as for Mailhog and PHPMyAdmin (in case you need to check outgoing emails or test things in the database). It also shows you the default credentials to use for the login. Sometimes it can take a few minutes for the process to complete, so please wait until it does!
+
+Then follow the test instructions in the pull request, and [report back your findings][report-findings]. The default username will always be admin, and the password will be ``Maut1cR0cks!``.
+
+.. note::
+
+   If you're testing an older version of Mautic than ``5.1``, use the password ``mautic``.
+
+If you are testing a bug and you need to reproduce this before you apply the pull request, you can use the link [https://gitpod.io/#https://github.com/mautic/mautic][gitpod-default] to spin up a Mautic instance based on our default branch.
+
+Top tips
+========
+
+Installing sample data
+----------------------
+
+To quickly install sample data, use the command ``ddev exec bin/console d:f:l`` which loads the Doctrine fixtures. It gives you a big head start with testing! 
+
+Build the segments after install
+--------------------------------
+
+It's always worth building the segments once you install the sample data, using the command ``ddev exec bin/console m:s:r``.  
+
+Testing with different databases / PHP versions
+-----------------------------------------------
+
+In DDEV we can set the database and PHP version in a file located in the folder ``.ddev/config.yaml``. 
+
+#. Open Gitpod from the PR you are testing and immediately stop the build process as soon as the terminal window is displayed, using ``command+c`` or ``ctrl+c`` on your keyboard.
+
+#. Delete anything that has already been started with the command ``ddev delete --omit-snapshot --yes && rm -rf var/cache && rm app/config/local.php``
+
+#. Edit the file in ``.ddev/config.yaml`` and change the setting. For instance, change DB from mariaDB 10.3 to mysql8. Always remember to save the file.
+
+   .. code-block:: yaml
+
+      mariadb_version: ""
+      mysql_version: "8.0"
+
+#. Type ``ddev start`` in the console to continue with installation.
+
+#. Run the installer in the UI or command line as preferred.
+
+#. Check you are using the right version in the system information within Mautic.
+
+#. Remember to make sure you are using dev mode - DDEV should start in dev mode by default with the Symfony toolbar at the bottom of the page.
+
+#. If you make a mistake, open your Gitpod dashboard and delete the instance and start again.
+
+Resetting your local testing environment
+----------------------------------------
+
+To quickly reset your local testing environment by deleting the DDEV containers without a database snapshot, removing the cache directory, and removing the ``local.php`` file you can run ``ddev delete --omit-snapshot --yes && rm -rf var/cache && rm app/config/local.php``. 
+
+Note that from Mautic 5, the location of the ``local.php`` file is now ``config/local.php``.
+
+Setting up a local testing environment
+**************************************
+
+Prerequisites
+=============
+
+Before starting, you will need a few pieces of software on your computer:
+* [Docker Desktop][docker-desktop]
+* [DDEV][ddev]
+* [Git][git]
+* [GitHub CLI][github-cli]
+
+Once you have these installed, we recommend that you use an editor such as [Visual Studio Code][vscode] which will allow you to interact with files, folders and the command line. There are other editors and Integrated Development Environments (IDEs) so if you already have one that you like, by all means use that!
+
+You will also need to register for an account at [github.com][github] if you don't already have one. This allows you to leave comments when you've tested things, and also means you can make fixes yourself in the future.
+
+Downloading Mautic
+==================
+
+To start testing, we need to download a copy of Mautic for us to work with.
+
+Before we do that, let's create a folder in your local computer where you'll locate all your local working environments. It's up to you where you save it and what you call it. Within that folder, create a folder where you'll work on this project - perhaps call it mautic4 for example.
+
+Open your editor, and within the editor, open a terminal window.  
+
+In the terminal, we need to move into the directory we just created.  Use the following commands:
+
+.. code-block:: bash
+
+   cd users/yourusername/yourfolder/mautic4
+
+If you need to move up an directory, for example back to ``/yourfolder/``, you can use the command:
+
+.. code-block:: bash
+
+   cd ..
+
+Once you are in the folder you want to work from, we need to pull down a copy of Mautic. To do this, we use a GitHub CLI command:
+
+.. code-block:: bash
+
+   gh repo clone mautic/mautic
+
+The first time you run this command, it will ask you to authenticate with GitHub. Just follow the steps, and once you've set up the authentication it won't bother you for some time.
+
+This will pull down the GitHub repository at [https://github.com/mautic/mautic][mautic-repo] to your local machine, ready for you to start testing with.
+
+Setting up a local DDEV instance
+================================
+
+Now we have the files locally, we need to move into the directory which was created using the command:
+
+.. code-block:: bash
+
+   cd mautic
+
+Now we need to spin up a server on our local computer, so that we can use PHP, MySQL and everything else that Mautic needs to run.
+
+To do this, use the command:
+
+.. code-block:: bash
+
+   ddev start
+
+The first time you run this command it might take a little while to run through the process.
+
+When you are prompted whether to install Mautic, choose 'yes'.
+
+This will install all the dependencies that Mautic requires to run, and will install Mautic with a default username and password:
+
+.. code-block:: text
+
+   username: admin
+   password: Maut1cR0cks!
+
+.. note::
+
+   If you're testing an older version of Mautic than ``5.1``, use the password ``mautic``.
+
+It will also install some software which allows you to capture outgoing emails, called Mailhog, and PHPMyAdmin, which enables you to view and interact with the database.
+
+Once this process has completed, you will be able to access your local testing instance at ``https://mautic.ddev.site``.
+
+Log in with the credentials above, and you're ready to go!
+
+.. tip::
+
+   If you're testing multiple versions of Mautic, such as ``4.x``, ``5.x``, ``6.x``, or ``7.x``, you don't need to manually change the ``name:`` in ``.ddev/config.yaml``. It's best to clone each into a separate folder by running:
+
+   .. code-block:: bash
+
+      git clone --branch 4.x https://github.com/mautic/mautic.git mautic4
+      git clone --branch 5.x https://github.com/mautic/mautic.git mautic5
+      git clone --branch 6.x https://github.com/mautic/mautic.git mautic6
+      git clone --branch 7.x https://github.com/mautic/mautic.git mautic7
+
+   DDEV uses the folder name as the project name, so this automatically gives you clean URLs like:
+
+   * ``https://mautic4.ddev.site``
+   * ``https://mautic5.ddev.site``
+   * ``https://mautic6.ddev.site``
+   * ``https://mautic7.ddev.site``
+
+Using developer mode
+********************
+
+When testing Mautic, it is important that you are notified of any errors rather than having them output to the logs.  We also don't want to have to constantly rebuild the JavaScript and CSS files when changes are made.
+
+For this reason, we use developer mode when testing in the Mautic Community, which is set in the local environment file.  DDEV has dev mode enabled by default - read more about [environments][environments].  
+
+Testing your first pull request
+*******************************
+
+The first step when testing a bug is to attempt reproducing the bug and making sure that you are experiencing the problem that the developer is fixing.
+
+Generally there will be instructions in the description of the pull request, but sometimes you might have to refer to an issue which reported the bug in order to find instructions for reproducing the issue.  If you don't understand, or can't reproduce the issue, please leave a comment and the developer will get back to you with further instructions.
+
+Once you have confirmed the bug, we need to apply the fix. We do this with another GitHub CLI command:
+
+.. code-block:: bash
+
+   gh pr checkout <number>
+
+Replace ``<number>`` with the ID number of the pull request. You can see this in the address bar, or next to the title of the pull request.
+
+This command pulls down the changes that the developer has made, and applies it to your local Mautic instance. It will also clear your cache automatically.
+
+If you ever need to clear the cache, you can either delete the cache folder manually or use the command:
+
+.. code-block:: bash
+
+   ddev exec bin/console cache:clear --env=dev
+
+Note that we have to prefix any commands with ``ddev exec`` so that they run inside the Docker container. We also use the ``--env=dev`` argument to specify that we need to clear the development (rather than production) cache.
+
+Now that you have the pull request applied, the next step is to re-test the bug or check out the new feature.  Make sure you are thorough in your testing. Really think about every possible thing that might be affected by the changes being made in the pull request, and test it in detail.
+
+It's very helpful if you can write a comment and explain what you have tested.
+
+Leaving your review
+*******************
+
+Within GitHub, there is a built-in system for people to leave reviews.  At the top of the pull request you will see a tab which is called 'Files Changed'. In this tab, at the top right, you'll see a green button which allows you to start a review.
+
+From this point, you can write what you have found when testing the pull request. You can select whether you approve the pull request, whether you think there are changes needed (e.g. if you weren't able to get the results that you expected) or just leave a comment if you're not sure either way, or just want to leave some feedback.
+
+Unloading the pull request
+**************************
+
+Once you are done with testing the pull request, it is good practice to get back to the original state. To do this use the command:
+
+.. code-block:: bash
+
+   git checkout 5.x
+
+Where 5.x is the branch that you want to return to.
+
+This will check out the branch called ``5.x`` which is where we started from.  Now you're ready to go and find another pull request to test! Have a little celebration, you helped make Mautic even more awesome! THANK YOU!
+
+
+[gitpod-browser]: <https://www.gitpod.io/docs/configure/user-settings/browser-extension>
+[docker-desktop]: <https://www.docker.com/products/docker-desktop>
+[ddev]: <https://ddev.readthedocs.io/en/stable/#installation>
+[github-cli]: <https://cli.github.com>
+[git]: <https://git-scm.com/download/>
+[vscode]: <https://code.visualstudio.com/download>
+[github]: <https://github.com/join>
+[mautic-repo]: <https://github.com/mautic/mautic>
+[environments]: <https://devdocs.mautic.org/en/5.x/development-environment/environments.html>
+[mautic-4.1]: <https://github.com/mautic/mautic/releases/tag/4.1.0>
+[gitpod]: <https://www.gitpod.io>
+[gitpod-default]: <https://gitpod.io/#https://github.com/mautic/mautic>
+[report-findings]: <https://contribute.mautic.org/contributing-to-mautic/tester#leaving-your-review>
+[open-source-friday-board]: <https://github.com/orgs/mautic/projects/13?pane=info>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,7 @@ The vision is that it grows over time as the teams and governance structure evol
    :hidden:
 
    contributing/designer
+   contributing/tester
    contributing/google_summer_of_code
    contributing/mautic_bounty_programme
    contributing/contributing_docs_rst

--- a/docs/links/ddev_get_started.py
+++ b/docs/links/ddev_get_started.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "DDEV get started" 
+link_text = "DDEV" 
+link_url = "https://ddev.readthedocs.io/en/stable/" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/docker_desktop.py
+++ b/docs/links/docker_desktop.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Docker Desktop" 
+link_text = "Docker Desktop" 
+link_url = "https://www.docker.com/products/docker-desktop" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/git_downloads.py
+++ b/docs/links/git_downloads.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Git downloads" 
+link_text = "Git" 
+link_url = "https://git-scm.com/downloads" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/github_cli.py
+++ b/docs/links/github_cli.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "GitHub CLI" 
+link_text = "GitHub CLI" 
+link_url = "https://cli.github.com" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/github_signup.py
+++ b/docs/links/github_signup.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "GitHub signup" 
+link_text = "GitHub" 
+link_url = "https://github.com/join" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/gitpod_browser_extension.py
+++ b/docs/links/gitpod_browser_extension.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Gitpod Browser Extension" 
+link_text = "Gitpod Browser Extension" 
+link_url = "https://www.gitpod.io/docs/configure/user-settings/browser-extension" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/gitpod_workspace_mautic.py
+++ b/docs/links/gitpod_workspace_mautic.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic Gitpod link" 
+link_text = "Gitpod link" 
+link_url = "https://gitpod.io/#https://github.com/mautic/mautic" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_environments_dev_docs.py
+++ b/docs/links/mautic_environments_dev_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic environments docs" 
+link_text = "Environments" 
+link_url = "https://devdocs.mautic.org/en/5.x/development-environment/environments.html" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_oss_friday_board.py
+++ b/docs/links/mautic_oss_friday_board.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic OSS Fridays board" 
+link_text = "Open Source Fridays board" 
+link_url = "https://github.com/orgs/mautic/projects/13?pane=info" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_v_41_release.py
+++ b/docs/links/mautic_v_41_release.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic 4.1 release" 
+link_text = "4.1 release" 
+link_url = "https://github.com/mautic/mautic/releases/tag/4.1.0" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_youtube_test_bugs_features.py
+++ b/docs/links/mautic_youtube_test_bugs_features.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "How to test bugs and features in Mautic" 
+link_text = "How to test bugs and features in Mautic" 
+link_url = "https://youtu.be/fqnT3kaDaW4?si=A2T2220CwM6Ly2zb" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/vscode.py
+++ b/docs/links/vscode.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "VS Code" 
+link_text = "Visual Studio Code" 
+link_url = "https://code.visualstudio.com/download" 
+
+link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
## Description

This PR converts the "Tester" section into RST.

## Linked Issue

Closes #358 

## Notes

In the existing section, we have a YouTube embed. After some research, the only way to embed a YouTube video is with [sphinxcontrib-youtube extension](https://sphinxcontrib-youtube.readthedocs.io/en/latest/). However, [the repository](https://github.com/sphinx-contrib/youtube?tab=readme-ov-file) seems no longer maintained (last updated was 2 years ago). So, I don't recommend this.

Therefore, I changed the embed into a tip admonition instead as screenshot below.

### Existing page - with embed

<img width="1233" height="708" alt="Screenshot 2025-07-31 001528" src="https://github.com/user-attachments/assets/4a7bac45-d3c0-4421-828e-cc8d57d116b5" />

### New version - tip admonition

<img width="1013" height="172" alt="Screenshot 2025-07-30 234153" src="https://github.com/user-attachments/assets/8c8dba15-930d-407b-9ada-f4a90b046888" />
