### PR TITLE
Ignore travel.dod.mil link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,4 +73,6 @@ linkcheck_ignore = [
     r"https://github.com/search*",
     # Gitpod URLs often follow the pattern https://gitpod.io/#<repository_url>, which is not in the traditional sense for an HTML page
     r'https://gitpod\.io/.*',
+    # The domain is blocking the link checker
+    r'https://www.travel.dod.mil/Travel-Transportation-Rates/Per-Diem/Rate-Lookup/',
 ]


### PR DESCRIPTION
There's a link which is blocking the link checker bot, yielding a 403 error which breaks the build check. This PR should add that link, https://www.travel.dod.mil/Travel-Transportation-Rates/Per-Diem/Rate-Lookup/, to the ignore link in the config file.