### PR TITLE
fix: Video render 

### DIFF
--- a/docs/links/youtube_prevent_burnout_jono_bacon.py
+++ b/docs/links/youtube_prevent_burnout_jono_bacon.py
@@ -1,7 +1,7 @@
 from . import link
 
-link_name = "Jono Bacon's how to prevent burnout video"
-link_text = "Jono Bacon's how to prevent burnout video"
+link_name = "How to Prevent Burnout in the Workplace"
+link_text = "How to Prevent Burnout in the Workplace"
 link_url = "https://www.youtube.com/watch?v=WC1bpYGoB7s" 
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/resources/community_wide_resources/avoiding_burnout.rst
+++ b/docs/resources/community_wide_resources/avoiding_burnout.rst
@@ -4,15 +4,11 @@ Avoiding burnout
 .. vale off 
 .. # Turning Vale off as this is a direct quote from Jono's book
 
-From The Art Of Community by O'Reilly :xref:`The Art of Community` by Jono Bacon, reproduced with permission.
+From :xref:`The Art of Community` by Jono Bacon, published by O'Reilly, reproduced with permission.
 
-.. raw:: html
+.. tip::
 
-    <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
-        <iframe src="https://www.youtube.com/watch?v=WC1bpYGoB7s" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
-    </div>
-
-:xref:`Jono Bacon's how to prevent burnout video` on YouTube.
+   You can watch Jono Bacon's :xref:`How to Prevent Burnout in the Workplace` video on YouTube, if you prefer a video format.
 
 Unfortunately, there is one other element in life that very specifically falls into the “not fun” category: burnout.
 

--- a/docs/resources/community_wide_resources/avoiding_burnout.rst
+++ b/docs/resources/community_wide_resources/avoiding_burnout.rst
@@ -10,6 +10,8 @@ From :xref:`The Art of Community` by Jono Bacon, published by O'Reilly, reproduc
 
    You can watch Jono Bacon's :xref:`How to Prevent Burnout in the Workplace` video on YouTube, if you prefer a video format.
 
+----
+
 Unfortunately, there is one other element in life that very specifically falls into the “not fun” category: burnout.
 
 NOTE:


### PR DESCRIPTION
## Description

Sphinx and Read the Docs is no longer support video embed. That's why, this PR changes the video embed into Tip in this section: https://contribute.mautic.org/en/latest/resources/community_wide_resources/avoiding_burnout.html.

Other than this, a horizontal line is added for clarity, renamed link file to start with lowecase for consistency, and modify the link name and text.