### PR TITLE
Add changes needed to show edit on GH link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,16 @@ templates_path = ['_templates']
 
 html_static_path = ['css']
 
+# GH Edit button
+
+html_context = {
+    "display_github": True,  # Integrate GitHub
+    "github_user": "mautic",  # Username
+    "github_repo": "mautic-community-handbook",  # Repository name
+    "github_version": "main/",  # Branch name
+    "conf_py_path": "/docs/",  # Path in the repository to conf.py
+}
+
 # -- Options for HTML output
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
This makes an 'edit on GitHub' link show on the docs pages.

See docs: https://docs.readthedocs.com/platform/latest/guides/edit-source-links-sphinx.html