### PR TITLE
Update the partners page

### DIFF
--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -30,6 +30,7 @@ Composer
 configurator
 ConnectWise
 Contribution(s)
+contribution(s)
 CORS
 CKEditor
 cron

--- a/docs/links/mautic_hosting_directory.py
+++ b/docs/links/mautic_hosting_directory.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic hosting directory" 
+link_text = "Mautic hosting directory" 
+link_url = "https://mautic.org/start-using-mautic/mautic-hosting/" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_members_partners.py
+++ b/docs/links/mautic_members_partners.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic Members and Partners database" 
+link_text = "Members and Partners database" 
+link_url = "https://mautic.org/members-partners/" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/policies/become_a_community_partner.rst
+++ b/docs/policies/become_a_community_partner.rst
@@ -3,11 +3,9 @@
 How to become a Mautic partner
 ##############################
 
-.. vale off
-
 The Mautic Partners Program showcases organizations that are contributing to Mautic - both financially and practically - so that members of the community can find service providers who are :xref:`Makers rather than takers` to work with. These organizations represent the ideals of providing ongoing contributions that open source software rely upon.
 
-.. vale on
+Mautic partners are featured much more prominently on the :xref:`Mautic Members and Partners database` which is used across the site to show filtered lists of providers with expertise in specific verticals and for the :xref:`Mautic hosting directory`. They are also eligible to be featured on the homepage if they're in the top three contributing partners for the previous month.
 
 How do organizations become a partner?
 **************************************
@@ -17,22 +15,18 @@ There are two elements to consider when reviewing an application to join the Par
 Financial contribution
 ======================
 
-.. vale off
+It's required that all Mautic Partners are financially supporting the growth of the Mautic community as a :xref:`Corporate Member of Mautic`. 
 
-It's required that all Community Partners are financially supporting the growth of the Mautic community as a :xref:`Corporate Member of Mautic`. Members pay for all memberships annually, via the website. Prior to v2 of the Mautic governance model which came into effect on ``12th December 2023``, companies who sponsored Mautic at $100 per month or more were also eligible. Companies who were already sponsoring at this tier when the new governance model came into effect and continue to do so are 'grandfathered' in, providing that their sponsorship continues at this tier, for a period of 12 months. This gives them until ``12th December 2024`` to transition to becoming a Corporate Member to maintain their status as a Mautic Partner.
+Members pay for all memberships annually, via the website. Historical members may still be renewing via Open Collective, if you'd like to switch to a direct payment via Stripe or invoice, please contact us at outreach@mautic.org.
 
-.. vale on
+Prior to v2 of the Mautic governance model which came into effect on ``12th December 2023``, companies who sponsored Mautic at $100 per month or more were also eligible to become partners. Companies who were already sponsoring at this tier when the new governance model came into effect and continue to do so are 'grandfathered' in, providing that their sponsorship continues at this tier, for a period of 12 months. This gives them until ``12th December 2024`` to transition to becoming a Corporate Member to maintain their status as a Mautic Partner.
 
 Practical contribution
 ======================
 
-.. vale off
+Of course money isn't everything, and in fact contributing to Mautic in practical ways, whether that might be through code contributions, leading a team, organizing official events or meetups, contributing to the documentation resources or working on tasks in one of the five community teams are all vital to the growth of the Mautic project.
 
-Of course money isn't everything, and in fact contributing to Mautic in practical ways, whether that might be through code contributions, leading a team, organizing official events or meetups, contributing to the Documentation resources or working on tasks in one of the five Community Teams are all vital to the growth of the Mautic project.
-
-For this reason, organizations who are wishing to become and maintain their status as a Mautic Community Partner must demonstrate regular, meaningful contributions to the Mautic project from their staff.
-
-.. vale on
+For this reason, organizations who are wishing to become and maintain their status as a Mautic Partner must demonstrate regular, meaningful contributions to the Mautic project from their staff.
 
 The Community Dashboard, team activity reviews, and project engagement metrics track this in several ways. These tools provide visibility into participation levels and outcomes across various team initiatives.
 
@@ -41,11 +35,7 @@ Organizations who aren't able to demonstrate a consistent contribution history m
 Ranking of organization
 =======================
 
-.. vale off
-
 Partners are ordered by their activity over the previous month, with the top three partners listed on the Mautic homepage with links to their Partner page.
-
-.. vale on
 
 Steps to become a Mautic community partner
 ******************************************
@@ -53,25 +43,17 @@ Steps to become a Mautic community partner
 Become a corporate member of Mautic
 ===================================
 
-.. vale off
-
-The first step is to start financially contributing to Mautic as a Corporate Member if you're not already. To do this you can sign up on the :xref:`Mautic Open Collective`. Be sure to switch to your organization account before you proceed with payment, so that it's associated with your company.
-
-.. vale on
+The first step is to start financially contributing to Mautic as a Corporate Member if you're not already. To do this head over to the membership page to become a :xref:`Corporate Member of Mautic`. If you require an invoice, please reach out to outreach@mautic.org and we'll be able to help - ensure you provide all the information required to be included in the invoice.
 
 Become a consistent contributor
 ===============================
 
 Once you have started contributing financially, take a look at where you are currently contributing to Mautic.
 
-Mautic needs every kind of skill from development to marketers, documentation writers, project managers, technical writers, designers - basically come with the skills and there's a place within Mautic to apply them effectively..
-
-.. vale off
+Mautic needs every kind of skill from development to marketers, documentation writers, project managers, technical writers, designers - basically come with the skills and there's a place within Mautic to apply them effectively.
 
 After you have been actively contributing in both financial and practical terms to Mautic for at least 3 months as an organization, please fill out :xref:`this form`.
 
-.. vale on
-
-Be sure to include  the names of team members to allow for verification of contribution history..
+Be sure to include the names of team members to allow for verification of contribution history..
 
 The application review takes a few weeks, with a response provided as soon as possible.


### PR DESCRIPTION
This PR updates the 'become a Mautic partner' page in the policies section to:

- Remove references to signing up via Open Collective
- Add links to the partners database and the hosting directory
- Remove Vale Off declarations where not necessary
- Add contribution(s) - lower case - to the accepted spelling list