### PR TITLE
Fixing local.php docs

### DIFF
--- a/docs/contributing/tester.rst
+++ b/docs/contributing/tester.rst
@@ -351,7 +351,7 @@ In DDEV, you can set the database and PHP version in a file located in the ``.dd
 
 #. :ref:`Set up a GitHub codespace<Setting up a codespace>` from the PR you are testing and immediately stop the build process as soon as the terminal window is displayed by pressing ``Cmd/Ctrl + C`` on your keyboard.
 
-#. Delete anything that has already been started with the command ``ddev delete --omit-snapshot --yes && rm -rf var/cache && rm app/config/local.php``.
+#. Delete anything that has already been started with the command ``ddev delete --omit-snapshot --yes && rm -rf var/cache && rm config/local.php``.
 
 #. Edit the file in ``.ddev/config.yaml`` and change the setting—for instance, change DB from MariaDB 10.3 to MySQL 8. Always remember to save the file.
 
@@ -362,7 +362,7 @@ In DDEV, you can set the database and PHP version in a file located in the ``.dd
 
 #. Type ``ddev start`` in the terminal to continue with installation.
 
-#. Run the installer in the UI or on the command line, as preferred. All the credentials for the database are ``db``.
+#. Run the installer in the UI or on the command line, as preferred. All the credentials for the database are ``db``. The database hostname is ``ddev-mautic-db``.
 
 #. Check that you're using the right version in the system information within Mautic.
 
@@ -377,7 +377,7 @@ To quickly reset your local testing environment by deleting the DDEV containers 
 
 .. code-block::
    
-   ddev delete --omit-snapshot --yes && rm -rf var/cache && rm app/config/local.php
+   ddev delete --omit-snapshot --yes && rm -rf var/cache && rm config/local.php
 
 Leaving a PR review
 *******************


### PR DESCRIPTION
The path to local.php seems to have changed.

## Description

The path to `local.php` no longer contains `app` it seems. Also added clarification of db hostname for `ddev` when doing a reinstall.

<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->