### PR TITLE
docs: Update instructions in "Git cherry-pic" section

### DIFF
--- a/docs/contributing/contributing_docs.rst
+++ b/docs/contributing/contributing_docs.rst
@@ -469,11 +469,27 @@ To cherry-pick, please follow the steps outlined below:
    
       git pull
 
-#. Ensure you have the commits you need for cherry-picking by fetching all new remote files, commits, and branches you don't have locally. To do so, run:
+#. Ensure you have the commits you need for cherry-picking by fetching all new remote files, commits, and branches you don't have locally from your remote repositories - ``origin`` and ``upstream``. To do so, run:
 
    .. code-block:: bash
    
-      git fetch origin
+      git fetch --all
+
+   .. tip::
+
+      If you haven't, add the original Mautic repository as your remote repository and name it ``upstream``. Run this command to add it:
+
+      .. code-block:: bash
+
+         git remote add upstream REMOTE-URL
+
+      To get the ``REMOTE-URL``:
+
+      #. Go to Mautic's original repository.
+      #. Click the green **Code** button.
+      #. In the **HTTPS** tab, copy the URL.
+      
+      Replace ``REMOTE-URL`` with the URL that you've copied.
 
 #. :ref:`Create a new branch`.
 


### PR DESCRIPTION
## Description

This PR updates the instructions in "Git cherry-pic" section with below details:

- Changed fetch instruction from `git fetch origin` to `git fetch --all` for simplicity.
- Added a tip admonition to add Mautic as `upstream` remote repository.


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue

N/A


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->