### PR TITLE
Docs: Fix duplicate and inaccurate status-based label descriptions

### DIFF
--- a/docs/governance/code_governance.rst
+++ b/docs/governance/code_governance.rst
@@ -199,9 +199,10 @@ Status-based labels
 * Pending feedback
 * Pending code changes
 * Has conflicts
-* Ready to test - PRs only, and only applied when the PR is passing tests, has no conflicts, has automated tests written and considered ready for merging
-* Pending test confirmation - PRs only, and only applied when the PR is passing tests, has no conflicts, has automated tests written and considered ready for merging
-* Ready to commit - PRs only, and only applied when the PR is passing tests, has no conflicts, has automated tests written, has the required signoff/approvals and considered ready for merging
+* Ready to test - PRs only, and only applied when the PR is ready for a tester to test it manually
+* Pending test confirmation - PRs only, and only applied when the PR needs one more tester to confirm it works before the Core Team merges it
+* User testing passed - PRs only, and only applied once the PR has been successfully tested by the required number of testers
+* Ready to commit - PRs only, and only applied when the PR has passed the required number of tester confirmations, has no conflicts, has automated tests written, has the required signoff/approvals, includes documentation, and is ready for the Core Team to merge
 
 Area Affected Labels - which part of the product does this affect?
 ==================================================================


### PR DESCRIPTION
## Description

`Ready to test` and `Pending test confirmation` had identical descriptions in the Status-based labels list (quoted below), which didn't reflect what each label actually means.

```rst
* Ready to test - PRs only, and only applied when the PR is passing tests, has no conflicts, has automated tests written and considered ready for merging
* Pending test confirmation - PRs only, and only applied when the PR is passing tests, has no conflicts, has automated tests written and considered ready for merging
* Ready to commit - PRs only, and only applied when the PR is passing tests, has no conflicts, has automated tests written, has the required signoff/approvals and considered ready for merging
```

I checked these labels' description and found the existing descriptions didn't match actual usage, so I've updated them:

* `Ready to test` - It now simply reflects that the PR is ready for a tester to test it manually.
* `Pending test confirmation` - now distinct from `Ready to test`. It reflects that the PR needs one more tester to confirm it works before merging, rather than repeating `Ready to test`'s description.
* `User testing passed` - added. This is an actively-used label that was missing from the list entirely.
* `Ready to commit` - updated to include the required number of tester confirmations and documentation as criteria.

### Live preview

https://mautic-community-handbook--448.org.readthedocs.build/en/448/governance/code_governance.html#status-based-labels


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue

N/A


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->