### PR TITLE
Fix: Broken external links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,4 +121,7 @@ linkcheck_ignore = [
     r"https://www.npmjs.com/",
     r"https://opencollective.com/*",
     r"https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951",
+    r"https://github.com/join",
+    r"https://github.com/signup",
+    r"https://governingopen.com/",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,4 +124,6 @@ linkcheck_ignore = [
     r"https://github.com/join",
     r"https://github.com/signup",
     r"https://governingopen.com/",
+    # 502 Server Error: Bad Gateway or Proxy Error
+    r"https://ubuntu.com/community",
 ]

--- a/docs/links/ubuntu_governance.py
+++ b/docs/links/ubuntu_governance.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Ubuntu governance" 
 link_text = "Ubuntu" 
-link_url = "https://ubuntu.com/community/governance" 
+link_url = "https://ubuntu.com/community" 
 
 link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
## Description

This PR fixes broken internal links with following details:

- Added 403 error domains and https://ubuntu.com/community to `conf.py`.
- Update link to Ubuntu governance page that leads to 502 Bad Gateway from https://ubuntu.com/community/governance to https://ubuntu.com/community. No exact replacement is available at the moment.


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue

N/A

<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->