### PR TITLE
fix: Broken link to install Vale page

### DIFF
--- a/docs/links/vale_install.py
+++ b/docs/links/vale_install.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "install Vale" 
 link_text = "install Vale" 
-link_url = "https://vale.sh/docs/vale-cli/installation/" 
+link_url = "https://docs.vale.sh/topics/installation" 
 
 link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
## Description

This PR fixes the broken link to https://vale.sh/docs/vale-cli/installation/.


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->